### PR TITLE
Update RestSharp to 106.11.7

### DIFF
--- a/SeatsioDotNet.Test/SeatsioDotNet.Test.csproj
+++ b/SeatsioDotNet.Test/SeatsioDotNet.Test.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="RestSharp" Version="106.5.4" />
+    <PackageReference Include="RestSharp" Version="106.11.7" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/SeatsioDotNet/SeatsioDotNet.csproj
+++ b/SeatsioDotNet/SeatsioDotNet.csproj
@@ -16,6 +16,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
-    <PackageReference Include="RestSharp" Version="106.5.4" />
+    <PackageReference Include="RestSharp" Version="106.11.7" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The older version of RestSharp has a forward-compatibility issue and conflicts with other popular packages that use versions newer than 106.5.4 [Docusign.eSign.dll](https://github.com/docusign/docusign-csharp-client) for one

See:
https://github.com/docusign/docusign-csharp-client/issues/156
https://github.com/restsharp/RestSharp/issues/1198
