### PR TITLE
Switch to using async all the way

### DIFF
--- a/SeatsioDotNet.Test/Charts/AddTagTest.cs
+++ b/SeatsioDotNet.Test/Charts/AddTagTest.cs
@@ -1,4 +1,5 @@
-﻿using SeatsioDotNet.Charts;
+﻿using System.Threading.Tasks;
+using SeatsioDotNet.Charts;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Charts;
@@ -6,25 +7,25 @@ namespace SeatsioDotNet.Test.Charts;
 public class AddTagTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var chart = Client.Charts.Create();
+        var chart = await Client.Charts.CreateAsync();
 
-        Client.Charts.AddTag(chart.Key, "tag1");
-        Client.Charts.AddTag(chart.Key, "tag2");
+        await Client.Charts.AddTagAsync(chart.Key, "tag1");
+        await Client.Charts.AddTagAsync(chart.Key, "tag2");
 
-        Chart retrievedChart = Client.Charts.Retrieve(chart.Key);
+        Chart retrievedChart = await Client.Charts.RetrieveAsync(chart.Key);
         CustomAssert.ContainsOnly(new[] {"tag1", "tag2"}, retrievedChart.Tags);
     }   
         
     [Fact]
-    public void SpecialCharacters()
+    public async Task SpecialCharacters()
     {
-        var chart = Client.Charts.Create();
+        var chart = await Client.Charts.CreateAsync();
 
-        Client.Charts.AddTag(chart.Key, "'tag1:-'/&?<>");
+        await Client.Charts.AddTagAsync(chart.Key, "'tag1:-'/&?<>");
 
-        Chart retrievedChart = Client.Charts.Retrieve(chart.Key);
+        Chart retrievedChart = await Client.Charts.RetrieveAsync(chart.Key);
         CustomAssert.ContainsOnly(new[] {"'tag1:-'/&?<>"}, retrievedChart.Tags);
     }
 }

--- a/SeatsioDotNet.Test/Charts/CopyChartFromWorkspaceToTest.cs
+++ b/SeatsioDotNet.Test/Charts/CopyChartFromWorkspaceToTest.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Charts;
@@ -5,18 +6,18 @@ namespace SeatsioDotNet.Test.Charts;
 public class CopyChartFromWorkspaceToTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var chart = Client.Charts.Create("my chart", "BOOTHS");
-        var toWorkspace = Client.Workspaces.Create("my ws");
+        var chart = await Client.Charts.CreateAsync("my chart", "BOOTHS");
+        var toWorkspace = await Client.Workspaces.CreateAsync("my ws");
 
-        var copiedChart = Client.Charts.CopyToWorkspace(chart.Key, Workspace.Key, toWorkspace.Key);
+        var copiedChart = await Client.Charts.CopyToWorkspaceAsync(chart.Key, Workspace.Key, toWorkspace.Key);
 
         Assert.Equal("my chart", copiedChart.Name);
         var workspaceClient = CreateSeatsioClient(toWorkspace.SecretKey);
-        var retrievedChart = workspaceClient.Charts.Retrieve(copiedChart.Key);
+        var retrievedChart = await workspaceClient.Charts.RetrieveAsync(copiedChart.Key);
         Assert.Equal("my chart", retrievedChart.Name);
-        var drawing = workspaceClient.Charts.RetrievePublishedVersion(copiedChart.Key);
+        var drawing = await workspaceClient.Charts.RetrievePublishedVersionAsync(copiedChart.Key);
         Assert.Equal("BOOTHS", drawing.VenueType);
     }
 }

--- a/SeatsioDotNet.Test/Charts/CopyChartTest.cs
+++ b/SeatsioDotNet.Test/Charts/CopyChartTest.cs
@@ -1,18 +1,19 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace SeatsioDotNet.Test.Charts;
 
 public class CopyChartTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var chart = Client.Charts.Create("my chart", "BOOTHS");
+        var chart = await Client.Charts.CreateAsync("my chart", "BOOTHS");
 
-        var copiedChart = Client.Charts.Copy(chart.Key);
+        var copiedChart = await Client.Charts.CopyAsync(chart.Key);
 
         Assert.Equal("my chart (copy)", copiedChart.Name);
-        var drawing = Client.Charts.RetrievePublishedVersion(copiedChart.Key);
+        var drawing = await Client.Charts.RetrievePublishedVersionAsync(copiedChart.Key);
         Assert.Equal("BOOTHS", drawing.VenueType);
     }
 }

--- a/SeatsioDotNet.Test/Charts/CopyChartToWorkspaceTest.cs
+++ b/SeatsioDotNet.Test/Charts/CopyChartToWorkspaceTest.cs
@@ -1,22 +1,23 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace SeatsioDotNet.Test.Charts;
 
 public class CopyChartToWorkspaceTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var chart = Client.Charts.Create("my chart", "BOOTHS");
-        var workspace = Client.Workspaces.Create("my ws");
+        var chart = await Client.Charts.CreateAsync("my chart", "BOOTHS");
+        var workspace = await Client.Workspaces.CreateAsync("my ws");
             
-        var copiedChart = Client.Charts.CopyToWorkspace(chart.Key, workspace.Key);
+        var copiedChart = await Client.Charts.CopyToWorkspaceAsync(chart.Key, workspace.Key);
             
         Assert.Equal("my chart", copiedChart.Name);
         var workspaceClient = CreateSeatsioClient(workspace.SecretKey);
-        var retrievedChart = workspaceClient.Charts.Retrieve(copiedChart.Key);
+        var retrievedChart = await workspaceClient.Charts.RetrieveAsync(copiedChart.Key);
         Assert.Equal("my chart", retrievedChart.Name);
-        var drawing = workspaceClient.Charts.RetrievePublishedVersion(copiedChart.Key);
+        var drawing = await workspaceClient.Charts.RetrievePublishedVersionAsync(copiedChart.Key);
         Assert.Equal("BOOTHS", drawing.VenueType);
     }
 }

--- a/SeatsioDotNet.Test/Charts/CopyDraftVersionTest.cs
+++ b/SeatsioDotNet.Test/Charts/CopyDraftVersionTest.cs
@@ -1,17 +1,18 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace SeatsioDotNet.Test.Charts;
 
 public class CopyDraftVersionTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var chart = Client.Charts.Create();
-        Client.Events.Create(chart.Key);
-        Client.Charts.Update(chart.Key, "newname");
+        var chart = await Client.Charts.CreateAsync();
+        await Client.Events.CreateAsync(chart.Key);
+        await Client.Charts.UpdateAsync(chart.Key, "newname");
             
-        var copiedChart = Client.Charts.CopyDraftVersion(chart.Key);
+        var copiedChart = await Client.Charts.CopyDraftVersionAsync(chart.Key);
             
         Assert.Equal("newname (copy)", copiedChart.Name);
     }

--- a/SeatsioDotNet.Test/Charts/CreateChartTest.cs
+++ b/SeatsioDotNet.Test/Charts/CreateChartTest.cs
@@ -1,4 +1,5 @@
-﻿using SeatsioDotNet.Charts;
+﻿using System.Threading.Tasks;
+using SeatsioDotNet.Charts;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Charts;
@@ -6,11 +7,11 @@ namespace SeatsioDotNet.Test.Charts;
 public class CreateChartTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var chart = Client.Charts.Create();
+        var chart = await Client.Charts.CreateAsync();
 
-        Chart retrievedChart = Client.Charts.Retrieve(chart.Key);
+        Chart retrievedChart = await Client.Charts.RetrieveAsync(chart.Key);
 
         Assert.NotEqual(0, retrievedChart.Id);
         Assert.NotNull(retrievedChart.Key);
@@ -22,51 +23,51 @@ public class CreateChartTest : SeatsioClientTest
         Assert.Empty(retrievedChart.Tags);
         Assert.False(retrievedChart.Archived);
 
-        var drawing = Client.Charts.RetrievePublishedVersion(chart.Key);
+        var drawing = await Client.Charts.RetrievePublishedVersionAsync(chart.Key);
         Assert.Equal("MIXED", drawing.VenueType);
         Assert.Empty(drawing.Categories);
     }
 
     [Fact]
-    public void Name()
+    public async Task Name()
     {
-        var chart = Client.Charts.Create("aChart");
+        var chart = await Client.Charts.CreateAsync("aChart");
 
-        Chart retrievedChart = Client.Charts.Retrieve(chart.Key);
+        Chart retrievedChart = await Client.Charts.RetrieveAsync(chart.Key);
 
         Assert.Equal("aChart", retrievedChart.Name);
-        var drawing = Client.Charts.RetrievePublishedVersion(chart.Key);
+        var drawing = await Client.Charts.RetrievePublishedVersionAsync(chart.Key);
         Assert.Equal("aChart", drawing.Name);
         Assert.Empty(drawing.Categories);
     }
 
     [Fact]
-    public void VenueType()
+    public async Task VenueType()
     {
-        var chart = Client.Charts.Create(null, "BOOTHS");
+        var chart = await Client.Charts.CreateAsync(null, "BOOTHS");
 
-        Chart retrievedChart = Client.Charts.Retrieve(chart.Key);
+        Chart retrievedChart = await Client.Charts.RetrieveAsync(chart.Key);
 
         Assert.Equal("Untitled chart", retrievedChart.Name);
-        var drawing = Client.Charts.RetrievePublishedVersion(chart.Key);
+        var drawing = await Client.Charts.RetrievePublishedVersionAsync(chart.Key);
         Assert.Equal("BOOTHS", drawing.VenueType);
         Assert.Empty(drawing.Categories);
     }
 
     [Fact]
-    public void Categories()
+    public async Task Categories()
     {
-        var chart = Client.Charts.Create(null, null, new[]
+        var chart = await Client.Charts.CreateAsync(null, null, new[]
         {
             new Category(1, "Category 1", "#aaaaaa"),
             new Category(2, "Category 2", "#bbbbbb", true),
             new Category("cat-3", "Category 3", "#cccccc")
         });
 
-        Chart retrievedChart = Client.Charts.Retrieve(chart.Key);
+        Chart retrievedChart = await Client.Charts.RetrieveAsync(chart.Key);
 
         Assert.Equal("Untitled chart", retrievedChart.Name);
-        var drawing = Client.Charts.RetrievePublishedVersion(chart.Key);
+        var drawing = await Client.Charts.RetrievePublishedVersionAsync(chart.Key);
         var actualCategories = drawing.Categories;
             
         Assert.Equal(3, actualCategories.Count);

--- a/SeatsioDotNet.Test/Charts/DiscardDraftVersionTest.cs
+++ b/SeatsioDotNet.Test/Charts/DiscardDraftVersionTest.cs
@@ -1,19 +1,20 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace SeatsioDotNet.Test.Charts;
 
 public class DiscardDraftTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var chart = Client.Charts.Create("oldname");
-        Client.Events.Create(chart.Key);
-        Client.Charts.Update(chart.Key, "newname");
+        var chart = await Client.Charts.CreateAsync("oldname");
+        await Client.Events.CreateAsync(chart.Key);
+        await Client.Charts.UpdateAsync(chart.Key, "newname");
 
-        Client.Charts.DiscardDraftVersion(chart.Key);
+        await Client.Charts.DiscardDraftVersionAsync(chart.Key);
 
-        var retrievedChart = Client.Charts.Retrieve(chart.Key);
+        var retrievedChart = await Client.Charts.RetrieveAsync(chart.Key);
         Assert.Equal("oldname", retrievedChart.Name);
         Assert.Equal("PUBLISHED", retrievedChart.Status);
     }

--- a/SeatsioDotNet.Test/Charts/ListAllTagsTest.cs
+++ b/SeatsioDotNet.Test/Charts/ListAllTagsTest.cs
@@ -1,20 +1,21 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace SeatsioDotNet.Test.Charts;
 
 public class ListAllTagsTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var chart1 = Client.Charts.Create();
-        Client.Charts.AddTag(chart1.Key, "tag1");
-        Client.Charts.AddTag(chart1.Key, "tag2");
+        var chart1 = await Client.Charts.CreateAsync();
+        await Client.Charts.AddTagAsync(chart1.Key, "tag1");
+        await Client.Charts.AddTagAsync(chart1.Key, "tag2");
 
-        var chart2 = Client.Charts.Create();
-        Client.Charts.AddTag(chart2.Key, "tag3");
+        var chart2 = await Client.Charts.CreateAsync();
+        await Client.Charts.AddTagAsync(chart2.Key, "tag3");
 
-        var tags = Client.Charts.ListAllTags();
+        var tags = await Client.Charts.ListAllTagsAsync();
         CustomAssert.ContainsOnly(new[] {"tag1", "tag2", "tag3"}, tags);
     }
 }

--- a/SeatsioDotNet.Test/Charts/ListChartsInArchiveTest.cs
+++ b/SeatsioDotNet.Test/Charts/ListChartsInArchiveTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Charts;
@@ -6,17 +7,17 @@ namespace SeatsioDotNet.Test.Charts;
 public class ListChartsInArchiveTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var chart1 = Client.Charts.Create();
-        Client.Charts.MoveToArchive(chart1.Key);
+        var chart1 = await Client.Charts.CreateAsync();
+        await Client.Charts.MoveToArchiveAsync(chart1.Key);
             
-        var chart2 = Client.Charts.Create();
+        var chart2 = await Client.Charts.CreateAsync();
             
-        var chart3 = Client.Charts.Create();
-        Client.Charts.MoveToArchive(chart3.Key);
+        var chart3 = await Client.Charts.CreateAsync();
+        await Client.Charts.MoveToArchiveAsync(chart3.Key);
 
-        var charts = Client.Charts.Archive.All();
+        var charts = await Client.Charts.Archive.AllAsync().ToListAsync();
         Assert.Equal(new [] { chart3.Key, chart1.Key}, charts.Select(c => c.Key));
     }
 }

--- a/SeatsioDotNet.Test/Charts/ListChartsTest.cs
+++ b/SeatsioDotNet.Test/Charts/ListChartsTest.cs
@@ -1,6 +1,8 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
+using SeatsioDotNet.Charts;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Charts;
@@ -22,13 +24,16 @@ public class ListChartsTest : SeatsioClientTest
     [Fact]
     public async Task MultiplePages()
     {
-        var chartTasks = Enumerable.Repeat("", 30).Select(async _ => await Client.Charts.CreateAsync());
-        var charts = await Task.WhenAll(chartTasks);
+        var charts = new List<Chart>();
+        for (var i = 1; i <= 30; i++)
+        {
+            var chart = await Client.Charts.CreateAsync();
+            charts.Add(chart);
+        }
 
         var retrievedCharts = await Client.Charts.ListAllAsync().ToListAsync();
 
-        charts.Select(c => c.Key).Should().NotContainInConsecutiveOrder(retrievedCharts.Select(c => c.Key));
-        // Assert.Equal(charts.Reverse().Select(c => c.Key), retrievedCharts.Select(c => c.Key));
+        Assert.Equal(charts.Select(c => c.Key).Reverse(), retrievedCharts.Select(c => c.Key));
     }
 
     [Fact]

--- a/SeatsioDotNet.Test/Charts/ListChartsTest.cs
+++ b/SeatsioDotNet.Test/Charts/ListChartsTest.cs
@@ -1,4 +1,6 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Charts;
@@ -6,74 +8,76 @@ namespace SeatsioDotNet.Test.Charts;
 public class ListChartsTest : SeatsioClientTest
 {
     [Fact]
-    public void All()
+    public async Task All()
     {
-        var chart1 = Client.Charts.Create();
-        var chart2 = Client.Charts.Create();
-        var chart3 = Client.Charts.Create();
+        var chart1 = await Client.Charts.CreateAsync();
+        var chart2 = await Client.Charts.CreateAsync();
+        var chart3 = await Client.Charts.CreateAsync();
 
-        var charts = Client.Charts.ListAll();
+        var charts = await Client.Charts.ListAllAsync().ToListAsync();
 
         Assert.Equal(new[] {chart3.Key, chart2.Key, chart1.Key}, charts.Select(c => c.Key));
     }
 
     [Fact]
-    public void MultiplePages()
+    public async Task MultiplePages()
     {
-        var charts = Enumerable.Repeat("", 30).Select(x => Client.Charts.Create());
+        var chartTasks = Enumerable.Repeat("", 30).Select(async _ => await Client.Charts.CreateAsync());
+        var charts = await Task.WhenAll(chartTasks);
 
-        var retrievedCharts = Client.Charts.ListAll();
+        var retrievedCharts = await Client.Charts.ListAllAsync().ToListAsync();
 
-        Assert.Equal(charts.Reverse().Select(c => c.Key), retrievedCharts.Select(c => c.Key));
+        charts.Select(c => c.Key).Should().NotContainInConsecutiveOrder(retrievedCharts.Select(c => c.Key));
+        // Assert.Equal(charts.Reverse().Select(c => c.Key), retrievedCharts.Select(c => c.Key));
     }
 
     [Fact]
-    public void Filter()
+    public async Task Filter()
     {
-        var chart1 = Client.Charts.Create("foo");
-        var chart2 = Client.Charts.Create("bar");
-        var chart3 = Client.Charts.Create("foofoo");
+        var chart1 = await Client.Charts.CreateAsync("foo");
+        var chart2 = await Client.Charts.CreateAsync("bar");
+        var chart3 = await Client.Charts.CreateAsync("foofoo");
 
-        var charts = Client.Charts.ListAll(filter: "foo");
+        var charts = await Client.Charts.ListAllAsync(filter: "foo").ToListAsync();
 
         Assert.Equal(new[] {chart3.Key, chart1.Key}, charts.Select(c => c.Key));
     }
 
     [Fact]
-    public void Tag()
+    public async Task Tag()
     {
-        var chart1 = Client.Charts.Create();
-        Client.Charts.AddTag(chart1.Key, "foo");
+        var chart1 = await Client.Charts.CreateAsync();
+        await Client.Charts.AddTagAsync(chart1.Key, "foo");
 
-        var chart2 = Client.Charts.Create();
+        var chart2 = await Client.Charts.CreateAsync();
 
-        var chart3 = Client.Charts.Create();
-        Client.Charts.AddTag(chart3.Key, "foo");
+        var chart3 = await Client.Charts.CreateAsync();
+        await Client.Charts.AddTagAsync(chart3.Key, "foo");
 
-        var charts = Client.Charts.ListAll(tag: "foo");
+        var charts = await Client.Charts.ListAllAsync(tag: "foo").ToListAsync();
 
         Assert.Equal(new[] {chart3.Key, chart1.Key}, charts.Select(c => c.Key));
     }
 
     [Fact]
-    public void Expand()
+    public async Task Expand()
     {
-        var chart = Client.Charts.Create();
-        var event1 = Client.Events.Create(chart.Key);
-        var event2 = Client.Events.Create(chart.Key);
+        var chart = await Client.Charts.CreateAsync();
+        var event1 = await Client.Events.CreateAsync(chart.Key);
+        var event2 = await Client.Events.CreateAsync(chart.Key);
 
-        var charts = Client.Charts.ListAll(expandEvents: true);
+        var charts = await Client.Charts.ListAllAsync(expandEvents: true).ToListAsync();
 
         Assert.Equal(new[] {event2.Id, event1.Id}, charts.First().Events.Select(c => c.Id));
     }   
         
     [Fact]
-    public void Validation()
+    public async Task Validation()
     {
         CreateTestChartWithErrors();
             
-        var charts = Client.Charts.ListAll(withValidation: true);
+        var chart = await Client.Charts.ListAllAsync(withValidation: true).FirstAsync();
 
-        Assert.NotNull(charts.First().Validation);
+        Assert.NotNull(chart.Validation);
     }
 }

--- a/SeatsioDotNet.Test/Charts/ManageCategoriesTest.cs
+++ b/SeatsioDotNet.Test/Charts/ManageCategoriesTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using SeatsioDotNet.Charts;
 using Xunit;
 
@@ -8,42 +9,42 @@ public class ManageCategoriesTest : SeatsioClientTest
 {
         
     [Fact]
-    public void AddCategory()
+    public async Task AddCategory()
     {
-        var chart = Client.Charts.Create("aChart", "BOOTHS");
+        var chart = await Client.Charts.CreateAsync("aChart", "BOOTHS");
             
-        Client.Charts.AddCategory(chart.Key, new Category(1, "cat 1", "#aaaaaa", true));
-        var drawing = Client.Charts.RetrievePublishedVersion(chart.Key);
+        await Client.Charts.AddCategoryAsync(chart.Key, new Category(1, "cat 1", "#aaaaaa", true));
+        var drawing = await Client.Charts.RetrievePublishedVersionAsync(chart.Key);
         Assert.Single(drawing.Categories);
     }
 
     [Fact]
-    public void RemoveCategory()
+    public async Task RemoveCategory()
     {
         var categories = new[]
         {
             new Category(1, "Category 1", "#aaaaaa"), 
             new Category("cat-2", "Category 2", "#bbbbbb", true)
         };
-        var chart = Client.Charts.Create("aChart", "BOOTHS", categories);
+        var chart = await Client.Charts.CreateAsync("aChart", "BOOTHS", categories);
             
-        Client.Charts.RemoveCategory(chart.Key, 1);
+        await Client.Charts.RemoveCategoryAsync(chart.Key, 1);
             
-        var drawing = Client.Charts.RetrievePublishedVersion(chart.Key);
+        var drawing = await Client.Charts.RetrievePublishedVersionAsync(chart.Key);
         Assert.Single(drawing.Categories);
     }
 
     [Fact]
-    public void ListCategories()
+    public async Task ListCategories()
     {
         var categories = new[]
         {
             new Category(1, "Category 1", "#aaaaaa"), 
             new Category("cat-2", "Category 2", "#bbbbbb", true)
         };
-        var chart = Client.Charts.Create("aChart", "BOOTHS", categories);
+        var chart = await Client.Charts.CreateAsync("aChart", "BOOTHS", categories);
             
-        IEnumerable<Category> categoryList = Client.Charts.ListCategories(chart.Key);
+        IEnumerable<Category> categoryList = await Client.Charts.ListCategoriesAsync(chart.Key);
         Assert.Equal(categories, categoryList);
     }
 }

--- a/SeatsioDotNet.Test/Charts/MoveChartOutOfArchiveTest.cs
+++ b/SeatsioDotNet.Test/Charts/MoveChartOutOfArchiveTest.cs
@@ -1,4 +1,5 @@
-﻿using SeatsioDotNet.Charts;
+﻿using System.Threading.Tasks;
+using SeatsioDotNet.Charts;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Charts;
@@ -6,14 +7,14 @@ namespace SeatsioDotNet.Test.Charts;
 public class MoveChartOutOfArchiveTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var chart = Client.Charts.Create();
-        Client.Charts.MoveToArchive(chart.Key);
+        var chart = await Client.Charts.CreateAsync();
+        await Client.Charts.MoveToArchiveAsync(chart.Key);
             
-        Client.Charts.MoveOutOfArchive(chart.Key);
+        await Client.Charts.MoveOutOfArchiveAsync(chart.Key);
 
-        Chart retrievedChart = Client.Charts.Retrieve(chart.Key);
+        Chart retrievedChart = await Client.Charts.RetrieveAsync(chart.Key);
         Assert.False(retrievedChart.Archived);
     }
 }

--- a/SeatsioDotNet.Test/Charts/MoveChartToArchiveTest.cs
+++ b/SeatsioDotNet.Test/Charts/MoveChartToArchiveTest.cs
@@ -1,4 +1,5 @@
-﻿using SeatsioDotNet.Charts;
+﻿using System.Threading.Tasks;
+using SeatsioDotNet.Charts;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Charts;
@@ -6,13 +7,13 @@ namespace SeatsioDotNet.Test.Charts;
 public class MoveChartToArchiveTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var chart = Client.Charts.Create();
+        var chart = await Client.Charts.CreateAsync();
 
-        Client.Charts.MoveToArchive(chart.Key);
+        await Client.Charts.MoveToArchiveAsync(chart.Key);
 
-        Chart retrievedChart = Client.Charts.Retrieve(chart.Key);
+        Chart retrievedChart = await Client.Charts.RetrieveAsync(chart.Key);
         Assert.True(retrievedChart.Archived);
     }
 }

--- a/SeatsioDotNet.Test/Charts/PublishDraftVersionTest.cs
+++ b/SeatsioDotNet.Test/Charts/PublishDraftVersionTest.cs
@@ -1,19 +1,20 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace SeatsioDotNet.Test.Charts;
 
 public class PublishDraftVersionTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var chart = Client.Charts.Create("oldname");
-        Client.Events.Create(chart.Key);
-        Client.Charts.Update(chart.Key, "newname");
+        var chart = await Client.Charts.CreateAsync("oldname");
+        await Client.Events.CreateAsync(chart.Key);
+        await Client.Charts.UpdateAsync(chart.Key, "newname");
 
-        Client.Charts.PublishDraftVersion(chart.Key);
+        await Client.Charts.PublishDraftVersionAsync(chart.Key);
 
-        var retrievedChart = Client.Charts.Retrieve(chart.Key);
+        var retrievedChart = await Client.Charts.RetrieveAsync(chart.Key);
         Assert.Equal("newname", retrievedChart.Name);
         Assert.Equal("PUBLISHED", retrievedChart.Status);
     }

--- a/SeatsioDotNet.Test/Charts/RemoveTagTest.cs
+++ b/SeatsioDotNet.Test/Charts/RemoveTagTest.cs
@@ -1,4 +1,5 @@
-﻿using SeatsioDotNet.Charts;
+﻿using System.Threading.Tasks;
+using SeatsioDotNet.Charts;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Charts;
@@ -6,15 +7,15 @@ namespace SeatsioDotNet.Test.Charts;
 public class RemoveTagTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var chart = Client.Charts.Create();
-        Client.Charts.AddTag(chart.Key, "tag1");
-        Client.Charts.AddTag(chart.Key, "tag2");
+        var chart = await Client.Charts.CreateAsync();
+        await Client.Charts.AddTagAsync(chart.Key, "tag1");
+        await Client.Charts.AddTagAsync(chart.Key, "tag2");
 
-        Client.Charts.RemoveTag(chart.Key, "tag2");
+        await Client.Charts.RemoveTagAsync(chart.Key, "tag2");
 
-        Chart retrievedChart = Client.Charts.Retrieve(chart.Key);
+        Chart retrievedChart = await Client.Charts.RetrieveAsync(chart.Key);
         CustomAssert.ContainsOnly(new[] {"tag1"}, retrievedChart.Tags);
     }
 }

--- a/SeatsioDotNet.Test/Charts/RetrieveChartTest.cs
+++ b/SeatsioDotNet.Test/Charts/RetrieveChartTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
 using SeatsioDotNet.Charts;
 using Xunit;
 
@@ -7,13 +8,13 @@ namespace SeatsioDotNet.Test.Charts;
 public class RetrieveChartTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var chart = Client.Charts.Create();
-        Client.Charts.AddTag(chart.Key, "tag1");
-        Client.Charts.AddTag(chart.Key, "tag2");
+        var chart = await Client.Charts.CreateAsync();
+        await Client.Charts.AddTagAsync(chart.Key, "tag1");
+        await Client.Charts.AddTagAsync(chart.Key, "tag2");
 
-        Chart retrievedChart = Client.Charts.Retrieve(chart.Key);
+        Chart retrievedChart = await Client.Charts.RetrieveAsync(chart.Key);
 
         Assert.NotEqual(0, retrievedChart.Id);
         Assert.NotNull(retrievedChart.Key);
@@ -27,13 +28,13 @@ public class RetrieveChartTest : SeatsioClientTest
     }
 
     [Fact]
-    public void WithEvents()
+    public async Task WithEvents()
     {
-        var chart = Client.Charts.Create();
-        var event1 = Client.Events.Create(chart.Key);
-        var event2 = Client.Events.Create(chart.Key);
+        var chart = await Client.Charts.CreateAsync();
+        var event1 = await Client.Events.CreateAsync(chart.Key);
+        var event2 = await Client.Events.CreateAsync(chart.Key);
 
-        Chart retrievedChart = Client.Charts.Retrieve(chart.Key, expandEvents: true);
+        Chart retrievedChart = await Client.Charts.RetrieveAsync(chart.Key, expandEvents: true);
 
         Assert.Equal(new[] {event2.Id, event1.Id}, retrievedChart.Events.Select(e => e.Id));
     }

--- a/SeatsioDotNet.Test/Charts/RetrieveDraftVersionTest.cs
+++ b/SeatsioDotNet.Test/Charts/RetrieveDraftVersionTest.cs
@@ -1,17 +1,18 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace SeatsioDotNet.Test.Charts;
 
 public class RetrieveDraftVersionTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var chart = Client.Charts.Create();
-        Client.Events.Create(chart.Key);
-        Client.Charts.Update(chart.Key, "aChart");
+        var chart = await Client.Charts.CreateAsync();
+        await Client.Events.CreateAsync(chart.Key);
+        await Client.Charts.UpdateAsync(chart.Key, "aChart");
 
-        var drawing = Client.Charts.RetrieveDraftVersion(chart.Key);
+        var drawing = await Client.Charts.RetrieveDraftVersionAsync(chart.Key);
         Assert.Equal("aChart", drawing.Name);
     }
 

--- a/SeatsioDotNet.Test/Charts/RetrieveDraftVersionThumbnailTest.cs
+++ b/SeatsioDotNet.Test/Charts/RetrieveDraftVersionThumbnailTest.cs
@@ -1,17 +1,18 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace SeatsioDotNet.Test.Charts;
 
 public class RetrieveDraftVersionThumbnailTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var chart = Client.Charts.Create();
-        Client.Events.Create(chart.Key);
-        Client.Charts.Update(chart.Key, "aChart");
+        var chart = await Client.Charts.CreateAsync();
+        await Client.Events.CreateAsync(chart.Key);
+        await Client.Charts.UpdateAsync(chart.Key, "aChart");
 
-        byte[] thumbnail = Client.Charts.RetrieveDraftVersionThumbnail(chart.Key);
+        byte[] thumbnail = await Client.Charts.RetrieveDraftVersionThumbnailAsync(chart.Key);
         Assert.NotEmpty(thumbnail);
     }
 }

--- a/SeatsioDotNet.Test/Charts/RetrievePublishedVersionTest.cs
+++ b/SeatsioDotNet.Test/Charts/RetrievePublishedVersionTest.cs
@@ -1,15 +1,16 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace SeatsioDotNet.Test.Charts;
 
 public class RetrievePublishedVersionTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var chart = Client.Charts.Create("aChart");
+        var chart = await Client.Charts.CreateAsync("aChart");
 
-        var drawing = Client.Charts.RetrievePublishedVersion(chart.Key);
+        var drawing = await Client.Charts.RetrievePublishedVersionAsync(chart.Key);
         Assert.Equal("aChart", drawing.Name);
     }
 

--- a/SeatsioDotNet.Test/Charts/RetrievePublishedVersionThumbnailTest.cs
+++ b/SeatsioDotNet.Test/Charts/RetrievePublishedVersionThumbnailTest.cs
@@ -1,15 +1,16 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace SeatsioDotNet.Test.Charts;
 
 public class RetrievePublishedVersionThumbnailTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var chart = Client.Charts.Create();
+        var chart = await Client.Charts.CreateAsync();
 
-        byte[] thumbnail = Client.Charts.RetrievePublishedVersionThumbnail(chart.Key);
+        byte[] thumbnail = await Client.Charts.RetrievePublishedVersionThumbnailAsync(chart.Key);
         Assert.NotEmpty(thumbnail);
     }
 }

--- a/SeatsioDotNet.Test/Charts/UpdateChartTest.cs
+++ b/SeatsioDotNet.Test/Charts/UpdateChartTest.cs
@@ -1,4 +1,5 @@
-﻿using SeatsioDotNet.Charts;
+﻿using System.Threading.Tasks;
+using SeatsioDotNet.Charts;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Charts;
@@ -6,29 +7,29 @@ namespace SeatsioDotNet.Test.Charts;
 public class UpdateChartTest : SeatsioClientTest
 {
     [Fact]
-    public void Name()
+    public async Task Name()
     {
-        var chart = Client.Charts.Create(null, "BOOTHS", new[] {new Category(1, "Category 1", "#aaaaaa")});
+        var chart = await Client.Charts.CreateAsync(null, "BOOTHS", new[] {new Category(1, "Category 1", "#aaaaaa")});
 
-        Client.Charts.Update(chart.Key, "aChart");
+        await Client.Charts.UpdateAsync(chart.Key, "aChart");
 
-        Chart retrievedChart = Client.Charts.Retrieve(chart.Key);
+        Chart retrievedChart = await Client.Charts.RetrieveAsync(chart.Key);
         Assert.Equal("aChart", retrievedChart.Name);
-        var drawing = Client.Charts.RetrievePublishedVersion(chart.Key);
+        var drawing = await Client.Charts.RetrievePublishedVersionAsync(chart.Key);
         Assert.Equal("BOOTHS", drawing.VenueType);
         Assert.Single(drawing.Categories);
     }
 
     [Fact]
-    public void Categories()
+    public async Task Categories()
     {
-        var chart = Client.Charts.Create("aChart", "BOOTHS");
+        var chart = await Client.Charts.CreateAsync("aChart", "BOOTHS");
 
-        Client.Charts.Update(chart.Key, categories: new[] {new Category(1, "Category 1", "#aaaaaa"), new Category("cat-2", "Category 2", "#bbbbbb", true)});
+        await Client.Charts.UpdateAsync(chart.Key, categories: new[] {new Category(1, "Category 1", "#aaaaaa"), new Category("cat-2", "Category 2", "#bbbbbb", true)});
 
-        Chart retrievedChart = Client.Charts.Retrieve(chart.Key);
+        Chart retrievedChart = await Client.Charts.RetrieveAsync(chart.Key);
         Assert.Equal("aChart", retrievedChart.Name);
-        var drawing = Client.Charts.RetrievePublishedVersion(chart.Key);
+        var drawing = await Client.Charts.RetrievePublishedVersionAsync(chart.Key);
         Assert.Equal("BOOTHS", drawing.VenueType);
         Assert.Equal(2, drawing.Categories.Count);
     }

--- a/SeatsioDotNet.Test/ErrorHandlingTest.cs
+++ b/SeatsioDotNet.Test/ErrorHandlingTest.cs
@@ -7,10 +7,10 @@ namespace SeatsioDotNet.Test;
 public class ErrorHandlingTest : SeatsioClientTest
 {
     [Fact]
-    public void Test4xx()
+    public async System.Threading.Tasks.Task Test4xx()
     {
-        var e = Assert.Throws<SeatsioException>(() =>
-            Client.Events.RetrieveObjectInfo("unexistingEvent", "unexistingObject"));
+        var e = await Assert.ThrowsAsync<SeatsioException>(async () =>
+            await Client.Events.RetrieveObjectInfoAsync("unexistingEvent", "unexistingObject"));
 
         Assert.Equal("Event not found: unexistingEvent.", e.Message);
         Assert.Contains(new SeatsioApiError("EVENT_NOT_FOUND", "Event not found: unexistingEvent"), e.Errors);
@@ -28,10 +28,10 @@ public class ErrorHandlingTest : SeatsioClientTest
     }
 
     [Fact]
-    public void WeirdError()
+    public async System.Threading.Tasks.Task WeirdError()
     {
-        var e = Assert.Throws<SeatsioException>(() =>
-            new SeatsioClient("", null, "unknownProtocol://").Events.RetrieveObjectInfo("unexistingEvent", "unexistingObject"));
+        var e = await Assert.ThrowsAsync<SeatsioException>(() =>
+            new SeatsioClient("", null, "unknownProtocol://").Events.RetrieveObjectInfoAsync("unexistingEvent", "unexistingObject"));
 
         Assert.Equal("Get  resulted in a 0  response. Body: ", e.Message);
         Assert.Null(e.Errors);

--- a/SeatsioDotNet.Test/EventLog/ListEventLogItemsTest.cs
+++ b/SeatsioDotNet.Test/EventLog/ListEventLogItemsTest.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SeatsioDotNet.Test.EventLog;
@@ -8,26 +9,26 @@ namespace SeatsioDotNet.Test.EventLog;
 public class ListEventLogItemsTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var chart = Client.Charts.Create();
-        Client.Charts.Update(chart.Key, "a chart");
+        var chart = await Client.Charts.CreateAsync();
+        await Client.Charts.UpdateAsync(chart.Key, "a chart");
 
         Thread.Sleep(2000);
 
-        var eventLogItems = Client.EventLog.ListAll();
+        var eventLogItems = Client.EventLog.ListAllAsync();
 
         Assert.Equal(new[] {"chart.created", "chart.published"}, eventLogItems.Select(e => e.Type));
     }
 
     [Fact]
-    public void Properties()
+    public async Task Properties()
     {
-        var chart = Client.Charts.Create();
+        var chart = await Client.Charts.CreateAsync();
 
         Thread.Sleep(2000);
 
-        var eventLogItem = Client.EventLog.ListAll().ToList()[0];
+        var eventLogItem = (await Client.EventLog.ListAllAsync().ToListAsync()).First();
 
         Assert.True(eventLogItem.Id > 0);
         Assert.Equal("chart.created", eventLogItem.Type);

--- a/SeatsioDotNet.Test/Events/BookObjectsTest.cs
+++ b/SeatsioDotNet.Test/Events/BookObjectsTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using SeatsioDotNet.EventReports;
 using SeatsioDotNet.Events;
@@ -10,30 +11,30 @@ namespace SeatsioDotNet.Test.Events;
 public class BookObjectsTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var result = Client.Events.Book(evnt.Key, new[] {"A-1", "A-2"});
+        var result = await Client.Events.BookAsync(evnt.Key, new[] {"A-1", "A-2"});
 
-        Assert.Equal(EventObjectInfo.Booked, Client.Events.RetrieveObjectInfo(evnt.Key, "A-1").Status);
-        Assert.Equal(EventObjectInfo.Booked, Client.Events.RetrieveObjectInfo(evnt.Key, "A-2").Status);
-        Assert.Equal(EventObjectInfo.Free, Client.Events.RetrieveObjectInfo(evnt.Key, "A-3").Status);
+        Assert.Equal(EventObjectInfo.Booked, (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1")).Status);
+        Assert.Equal(EventObjectInfo.Booked, (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-2")).Status);
+        Assert.Equal(EventObjectInfo.Free, (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-3")).Status);
         CustomAssert.ContainsOnly(new[] {"A-1", "A-2"}, result.Objects.Keys);
     }
 
     [Fact]
-    public void Sections()
+    public async Task Sections()
     {
         var chartKey = CreateTestChartWithSections();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var result = Client.Events.Book(evnt.Key, new[] {"Section A-A-1", "Section A-A-2"});
+        var result = await Client.Events.BookAsync(evnt.Key, new[] {"Section A-A-1", "Section A-A-2"});
 
-        Assert.Equal(EventObjectInfo.Booked, Client.Events.RetrieveObjectInfo(evnt.Key, "Section A-A-1").Status);
-        Assert.Equal(EventObjectInfo.Booked, Client.Events.RetrieveObjectInfo(evnt.Key, "Section A-A-2").Status);
-        Assert.Equal(EventObjectInfo.Free, Client.Events.RetrieveObjectInfo(evnt.Key, "Section A-A-3").Status);
+        Assert.Equal(EventObjectInfo.Booked, (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "Section A-A-1")).Status);
+        Assert.Equal(EventObjectInfo.Booked, (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "Section A-A-2")).Status);
+        Assert.Equal(EventObjectInfo.Free, (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "Section A-A-3")).Status);
 
         var reportItem = result.Objects["Section A-A-1"];
         Assert.Equal("Section A", reportItem.Section);
@@ -43,77 +44,77 @@ public class BookObjectsTest : SeatsioClientTest
     }
 
     [Fact]
-    public void HoldToken()
+    public async Task HoldToken()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        HoldToken holdToken = Client.HoldTokens.Create();
-        Client.Events.Hold(evnt.Key, new[] {"A-1", "A-2"}, holdToken.Token);
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        HoldToken holdToken = await Client.HoldTokens.CreateAsync();
+        await Client.Events.HoldAsync(evnt.Key, new[] {"A-1", "A-2"}, holdToken.Token);
 
-        Client.Events.Book(evnt.Key, new[] {"A-1", "A-2"}, holdToken.Token);
+        await Client.Events.BookAsync(evnt.Key, new[] {"A-1", "A-2"}, holdToken.Token);
 
-        var objectInfo1 = Client.Events.RetrieveObjectInfo(evnt.Key, "A-1");
+        var objectInfo1 = await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1");
         Assert.Equal(EventObjectInfo.Booked, objectInfo1.Status);
         Assert.Null(objectInfo1.HoldToken);
 
-        var objectInfo2 = Client.Events.RetrieveObjectInfo(evnt.Key, "A-2");
+        var objectInfo2 = await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-2");
         Assert.Equal(EventObjectInfo.Booked, objectInfo2.Status);
         Assert.Null(objectInfo2.HoldToken);
     }
 
     [Fact]
-    public void OrderId()
+    public async Task OrderId()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        Client.Events.Book(evnt.Key, new[] {"A-1", "A-2"}, null, "order1");
+        await Client.Events.BookAsync(evnt.Key, new[] {"A-1", "A-2"}, null, "order1");
 
-        Assert.Equal("order1", Client.Events.RetrieveObjectInfo(evnt.Key, "A-1").OrderId);
-        Assert.Equal("order1", Client.Events.RetrieveObjectInfo(evnt.Key, "A-2").OrderId);
+        Assert.Equal("order1", (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1")).OrderId);
+        Assert.Equal("order1", (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-2")).OrderId);
     }
 
     [Fact]
-    public void KeepExtraData()
+    public async Task KeepExtraData()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
         var extraData = new Dictionary<string, object> {{"foo1", "bar1"}};
-        Client.Events.UpdateExtraData(evnt.Key, "A-1", extraData);
+        await Client.Events.UpdateExtraDataAsync(evnt.Key, "A-1", extraData);
 
-        Client.Events.Book(evnt.Key, new[] {"A-1"}, null, null, true);
+        await Client.Events.BookAsync(evnt.Key, new[] {"A-1"}, null, null, true);
 
-        var loadedExtraData = Client.Events.RetrieveObjectInfo(evnt.Key, "A-1").ExtraData;
-        Assert.Equal(extraData, loadedExtraData);
+        var loadedExtraData = await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1");
+        Assert.Equal(extraData, loadedExtraData.ExtraData);
     }
 
     [Fact]
-    public void ChannelKeys()
+    public async Task ChannelKeys()
     {
         var chartKey = CreateTestChart();
         var channels = new List<Channel>
         {
             new("channelKey1", "channel 1", "#FFFF00", 1, new[] {"A-1", "A-2"})
         };
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithChannels(channels));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithChannels(channels));
 
-        Client.Events.Book(evnt.Key, new[] {"A-1"}, null, null, true, null, new[] {"channelKey1"});
+        await Client.Events.BookAsync(evnt.Key, new[] {"A-1"}, null, null, true, null, new[] {"channelKey1"});
 
-        Assert.Equal(EventObjectInfo.Booked, Client.Events.RetrieveObjectInfo(evnt.Key, "A-1").Status);
+        Assert.Equal(EventObjectInfo.Booked, (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1")).Status);
     }   
         
     [Fact]
-    public void IgnoreChannels()
+    public async Task IgnoreChannels()
     {
         var chartKey = CreateTestChart();
         var channels = new List<Channel>
         {
             new("channelKey1", "channel 1", "#FFFF00", 1, new[] {"A-1", "A-2"})
         };
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithChannels(channels));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithChannels(channels));
 
-        Client.Events.Book(evnt.Key, new[] {"A-1"}, null, null, true, true);
+        await Client.Events.BookAsync(evnt.Key, new[] {"A-1"}, null, null, true, true);
 
-        Assert.Equal(EventObjectInfo.Booked, Client.Events.RetrieveObjectInfo(evnt.Key, "A-1").Status);
+        Assert.Equal(EventObjectInfo.Booked, (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1")).Status);
     }
 }

--- a/SeatsioDotNet.Test/Events/ChangeBestAvailableObjectStatusTest.cs
+++ b/SeatsioDotNet.Test/Events/ChangeBestAvailableObjectStatusTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using SeatsioDotNet.Events;
 using Xunit;
@@ -8,24 +9,24 @@ namespace SeatsioDotNet.Test.Events;
 public class ChangeBestAvailableObjectStatusTest : SeatsioClientTest
 {
     [Fact]
-    public void Number()
+    public async Task Number()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var bestAvailableResult = Client.Events.ChangeObjectStatus(evnt.Key, new BestAvailable(3), "foo");
+        var bestAvailableResult = await Client.Events.ChangeObjectStatusAsync(evnt.Key, new BestAvailable(3), "foo");
 
         Assert.True(bestAvailableResult.NextToEachOther);
         Assert.Equal(new[] {"A-4", "A-5", "A-6"}, bestAvailableResult.Objects);
     }
 
     [Fact]
-    public void ObjectDetails()
+    public async Task ObjectDetails()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var bestAvailableResult = Client.Events.ChangeObjectStatus(evnt.Key, new BestAvailable(2), "foo");
+        var bestAvailableResult = await Client.Events.ChangeObjectStatusAsync(evnt.Key, new BestAvailable(2), "foo");
 
         var reportItem = bestAvailableResult.ObjectDetails["A-4"];
         Assert.Equal("A-4", reportItem.Label);
@@ -47,130 +48,130 @@ public class ChangeBestAvailableObjectStatusTest : SeatsioClientTest
     }
 
     [Fact]
-    public void Categories()
+    public async Task Categories()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var bestAvailableResult = Client.Events.ChangeObjectStatus(evnt.Key, new BestAvailable(3, new[] {"cat2"}), "foo");
+        var bestAvailableResult = await Client.Events.ChangeObjectStatusAsync(evnt.Key, new BestAvailable(3, new[] {"cat2"}), "foo");
 
         Assert.True(bestAvailableResult.NextToEachOther);
         Assert.Equal(new[] {"C-4", "C-5", "C-6"}, bestAvailableResult.Objects);
     }
 
     [Fact]
-    public void ExtraData()
+    public async Task ExtraData()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
         var extraData = new[]
         {
             new Dictionary<string, object> {{"foo", "bar"}},
             new Dictionary<string, object> {{"foo", "baz"}}
         };
 
-        var bestAvailableResult = Client.Events.ChangeObjectStatus(evnt.Key, new BestAvailable(2, extraData: extraData), "foo");
+        var bestAvailableResult = await Client.Events.ChangeObjectStatusAsync(evnt.Key, new BestAvailable(2, extraData: extraData), "foo");
 
         Assert.Equal(new[] {"A-4", "A-5"}, bestAvailableResult.Objects);
-        Assert.Equal(new Dictionary<string, object> {{"foo", "bar"}}, Client.Events.RetrieveObjectInfo(evnt.Key, "A-4").ExtraData);
-        Assert.Equal(new Dictionary<string, object> {{"foo", "baz"}}, Client.Events.RetrieveObjectInfo(evnt.Key, "A-5").ExtraData);
+        Assert.Equal(new Dictionary<string, object> {{"foo", "bar"}}, (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-4")).ExtraData);
+        Assert.Equal(new Dictionary<string, object> {{"foo", "baz"}}, (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-5")).ExtraData);
     }   
         
     [Fact]
-    public void DoNotTryToPreventOrphanSeats()
+    public async Task DoNotTryToPreventOrphanSeats()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.Book(evnt.Key, new[] {"A-4", "A-5"});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.BookAsync(evnt.Key, new[] {"A-4", "A-5"});
 
-        var bestAvailableResult = Client.Events.ChangeObjectStatus(evnt.Key, new BestAvailable(2, tryToPreventOrphanSeats: false), "foo");
+        var bestAvailableResult = await Client.Events.ChangeObjectStatusAsync(evnt.Key, new BestAvailable(2, tryToPreventOrphanSeats: false), "foo");
 
         Assert.Equal(new[] {"A-2", "A-3"}, bestAvailableResult.Objects);
     }
 
     [Fact]
-    public void TicketTypes()
+    public async Task TicketTypes()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
         var extraData = new[]
         {
             new Dictionary<string, object> {{"foo", "bar"}},
             new Dictionary<string, object> {{"foo", "baz"}}
         };
 
-        var bestAvailableResult = Client.Events.ChangeObjectStatus(evnt.Key, new BestAvailable(2, ticketTypes: new[]{"adult", "child"}), "foo");
+        var bestAvailableResult = await Client.Events.ChangeObjectStatusAsync(evnt.Key, new BestAvailable(2, ticketTypes: new[]{"adult", "child"}), "foo");
 
         Assert.Equal(new[] {"A-4", "A-5"}, bestAvailableResult.Objects);
-        Assert.Equal("adult", Client.Events.RetrieveObjectInfo(evnt.Key, "A-4").TicketType);
-        Assert.Equal("child", Client.Events.RetrieveObjectInfo(evnt.Key, "A-5").TicketType);
+        Assert.Equal("adult", (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-4")).TicketType);
+        Assert.Equal("child", (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-5")).TicketType);
     }
 
     [Fact]
-    public void KeepExtraDataTrue()
+    public async Task KeepExtraDataTrue()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
         var extraData = new Dictionary<string, object> {{"foo1", "bar1"}};
-        Client.Events.UpdateExtraData(evnt.Key, "A-5", extraData);
+        await Client.Events.UpdateExtraDataAsync(evnt.Key, "A-5", extraData);
 
-        Client.Events.ChangeObjectStatus(evnt.Key, new BestAvailable(1), "someStatus", null, null, true);
+        await Client.Events.ChangeObjectStatusAsync(evnt.Key, new BestAvailable(1), "someStatus", null, null, true);
 
-        Assert.Equal(extraData, Client.Events.RetrieveObjectInfo(evnt.Key, "A-5").ExtraData);
+        Assert.Equal(extraData,(await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-5")).ExtraData);
     }
 
     [Fact]
-    public void KeepExtraDataFalse()
+    public async Task KeepExtraDataFalse()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
         var extraData = new Dictionary<string, object> {{"foo1", "bar1"}};
-        Client.Events.UpdateExtraData(evnt.Key, "A-5", extraData);
+        await Client.Events.UpdateExtraDataAsync(evnt.Key, "A-5", extraData);
 
-        Client.Events.ChangeObjectStatus(evnt.Key, new BestAvailable(1), "someStatus", null, null, false);
+        await Client.Events.ChangeObjectStatusAsync(evnt.Key, new BestAvailable(1), "someStatus", null, null, false);
 
-        Assert.Null(Client.Events.RetrieveObjectInfo(evnt.Key, "A-5").ExtraData);
+        Assert.Null((await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-5")).ExtraData);
     }
 
     [Fact]
-    public void NoKeepExtraData()
+    public async Task NoKeepExtraData()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
         var extraData = new Dictionary<string, object> {{"foo1", "bar1"}};
-        Client.Events.UpdateExtraData(evnt.Key, "A-5", extraData);
+        await Client.Events.UpdateExtraDataAsync(evnt.Key, "A-5", extraData);
 
-        Client.Events.ChangeObjectStatus(evnt.Key, new BestAvailable(1), "someStatus");
+        await Client.Events.ChangeObjectStatusAsync(evnt.Key, new BestAvailable(1), "someStatus");
 
-        Assert.Null(Client.Events.RetrieveObjectInfo(evnt.Key, "A-5").ExtraData);
+        Assert.Null((await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-5")).ExtraData);
     }
 
     [Fact]
-    public void ChannelKeys()
+    public async Task ChannelKeys()
     {
         var chartKey = CreateTestChart();
         var channels = new List<Channel>
         {
             new("channelKey1", "channel 1", "#FFFF00", 1, new[] {"A-6"})
         };
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithChannels(channels));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithChannels(channels));
             
-        var bestAvailableResult = Client.Events.ChangeObjectStatus(evnt.Key, new BestAvailable(1), "someStatus", channelKeys: new[] {"channelKey1"});
+        var bestAvailableResult = await Client.Events.ChangeObjectStatusAsync(evnt.Key, new BestAvailable(1), "someStatus", channelKeys: new[] {"channelKey1"});
 
         Assert.Equal(new[] {"A-6"}, bestAvailableResult.Objects);
     }   
         
     [Fact]
-    public void IgnoreChannels()
+    public async Task IgnoreChannels()
     {
         var chartKey = CreateTestChart();
         var channels = new List<Channel>
         {
             new("channelKey1", "channel 1", "#FFFF00", 1, new[] {"A-5"})
         };
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithChannels(channels));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithChannels(channels));
 
-        var bestAvailableResult = Client.Events.ChangeObjectStatus(evnt.Key, new BestAvailable(1), "someStatus", ignoreChannels: true);
+        var bestAvailableResult = await Client.Events.ChangeObjectStatusAsync(evnt.Key, new BestAvailable(1), "someStatus", ignoreChannels: true);
 
         Assert.Equal(new[] {"A-5"}, bestAvailableResult.Objects);
     }

--- a/SeatsioDotNet.Test/Events/ChangeObjectStatusForMultipleEventsTest.cs
+++ b/SeatsioDotNet.Test/Events/ChangeObjectStatusForMultipleEventsTest.cs
@@ -1,4 +1,5 @@
-﻿using SeatsioDotNet.EventReports;
+﻿using System.Threading.Tasks;
+using SeatsioDotNet.EventReports;
 using SeatsioDotNet.HoldTokens;
 using Xunit;
 
@@ -7,64 +8,64 @@ namespace SeatsioDotNet.Test.Events;
 public class ChangeObjectStatusForMultipleEventsTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
         var chartKey = CreateTestChart();
-        var event1 = Client.Events.Create(chartKey);
-        var event2 = Client.Events.Create(chartKey);
+        var event1 = await Client.Events.CreateAsync(chartKey);
+        var event2 = await Client.Events.CreateAsync(chartKey);
 
-        Client.Events.ChangeObjectStatus(new[] {event1.Key, event2.Key}, new[] {"A-1", "A-2"}, "foo");
+        await Client.Events.ChangeObjectStatusAsync(new[] {event1.Key, event2.Key}, new[] {"A-1", "A-2"}, "foo");
 
-        Assert.Equal("foo", Client.Events.RetrieveObjectInfo(event1.Key, "A-1").Status);
-        Assert.Equal("foo", Client.Events.RetrieveObjectInfo(event1.Key, "A-2").Status);
-        Assert.Equal("foo", Client.Events.RetrieveObjectInfo(event2.Key, "A-1").Status);
-        Assert.Equal("foo", Client.Events.RetrieveObjectInfo(event2.Key, "A-2").Status);
+        Assert.Equal("foo", (await Client.Events.RetrieveObjectInfoAsync(event1.Key, "A-1")).Status);
+        Assert.Equal("foo", (await Client.Events.RetrieveObjectInfoAsync(event1.Key, "A-2")).Status);
+        Assert.Equal("foo", (await Client.Events.RetrieveObjectInfoAsync(event2.Key, "A-1")).Status);
+        Assert.Equal("foo", (await Client.Events.RetrieveObjectInfoAsync(event2.Key, "A-2")).Status);
     }      
         
     [Fact]
-    public void Book()
+    public async Task Book()
     {
         var chartKey = CreateTestChart();
-        var event1 = Client.Events.Create(chartKey);
-        var event2 = Client.Events.Create(chartKey);
+        var event1 = await Client.Events.CreateAsync(chartKey);
+        var event2 = await Client.Events.CreateAsync(chartKey);
 
-        Client.Events.Book(new[] {event1.Key, event2.Key}, new[] {"A-1", "A-2"});
+        await Client.Events.BookAsync(new[] {event1.Key, event2.Key}, new[] {"A-1", "A-2"});
 
-        Assert.Equal(EventObjectInfo.Booked, Client.Events.RetrieveObjectInfo(event1.Key, "A-1").Status);
-        Assert.Equal(EventObjectInfo.Booked, Client.Events.RetrieveObjectInfo(event1.Key, "A-2").Status);
-        Assert.Equal(EventObjectInfo.Booked, Client.Events.RetrieveObjectInfo(event2.Key, "A-1").Status);
-        Assert.Equal(EventObjectInfo.Booked, Client.Events.RetrieveObjectInfo(event2.Key, "A-2").Status);
+        Assert.Equal(EventObjectInfo.Booked, (await Client.Events.RetrieveObjectInfoAsync(event1.Key, "A-1")).Status);
+        Assert.Equal(EventObjectInfo.Booked, (await Client.Events.RetrieveObjectInfoAsync(event1.Key, "A-2")).Status);
+        Assert.Equal(EventObjectInfo.Booked, (await Client.Events.RetrieveObjectInfoAsync(event2.Key, "A-1")).Status);
+        Assert.Equal(EventObjectInfo.Booked, (await Client.Events.RetrieveObjectInfoAsync(event2.Key, "A-2")).Status);
     } 
         
     [Fact]
-    public void Hold()
+    public async Task Hold()
     {
         var chartKey = CreateTestChart();
-        var event1 = Client.Events.Create(chartKey);
-        var event2 = Client.Events.Create(chartKey);
-        HoldToken holdToken = Client.HoldTokens.Create();
+        var event1 = await Client.Events.CreateAsync(chartKey);
+        var event2 = await Client.Events.CreateAsync(chartKey);
+        HoldToken holdToken = await Client.HoldTokens.CreateAsync();
             
-        Client.Events.Hold(new[] {event1.Key, event2.Key}, new[] {"A-1", "A-2"}, holdToken.Token);
+        await Client.Events.HoldAsync(new[] {event1.Key, event2.Key}, new[] {"A-1", "A-2"}, holdToken.Token);
 
-        Assert.Equal(EventObjectInfo.Held, Client.Events.RetrieveObjectInfo(event1.Key, "A-1").Status);
-        Assert.Equal(EventObjectInfo.Held, Client.Events.RetrieveObjectInfo(event1.Key, "A-2").Status);
-        Assert.Equal(EventObjectInfo.Held, Client.Events.RetrieveObjectInfo(event2.Key, "A-1").Status);
-        Assert.Equal(EventObjectInfo.Held, Client.Events.RetrieveObjectInfo(event2.Key, "A-2").Status);
+        Assert.Equal(EventObjectInfo.Held, (await Client.Events.RetrieveObjectInfoAsync(event1.Key, "A-1")).Status);
+        Assert.Equal(EventObjectInfo.Held, (await Client.Events.RetrieveObjectInfoAsync(event1.Key, "A-2")).Status);
+        Assert.Equal(EventObjectInfo.Held, (await Client.Events.RetrieveObjectInfoAsync(event2.Key, "A-1")).Status);
+        Assert.Equal(EventObjectInfo.Held, (await Client.Events.RetrieveObjectInfoAsync(event2.Key, "A-2")).Status);
     }  
         
     [Fact]
-    public void Release()
+    public async Task Release()
     {
         var chartKey = CreateTestChart();
-        var event1 = Client.Events.Create(chartKey);
-        var event2 = Client.Events.Create(chartKey);
-        Client.Events.Book(new[] {event1.Key, event2.Key}, new[] {"A-1", "A-2"});
+        var event1 = await Client.Events.CreateAsync(chartKey);
+        var event2 = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.BookAsync(new[] {event1.Key, event2.Key}, new[] {"A-1", "A-2"});
             
-        Client.Events.Release(new[] {event1.Key, event2.Key}, new[] {"A-1", "A-2"});
+        await Client.Events.ReleaseAsync(new[] {event1.Key, event2.Key}, new[] {"A-1", "A-2"});
 
-        Assert.Equal(EventObjectInfo.Free, Client.Events.RetrieveObjectInfo(event1.Key, "A-1").Status);
-        Assert.Equal(EventObjectInfo.Free, Client.Events.RetrieveObjectInfo(event1.Key, "A-2").Status);
-        Assert.Equal(EventObjectInfo.Free, Client.Events.RetrieveObjectInfo(event2.Key, "A-1").Status);
-        Assert.Equal(EventObjectInfo.Free, Client.Events.RetrieveObjectInfo(event2.Key, "A-2").Status);
+        Assert.Equal(EventObjectInfo.Free, (await Client.Events.RetrieveObjectInfoAsync(event1.Key, "A-1")).Status);
+        Assert.Equal(EventObjectInfo.Free, (await Client.Events.RetrieveObjectInfoAsync(event1.Key, "A-2")).Status);
+        Assert.Equal(EventObjectInfo.Free, (await Client.Events.RetrieveObjectInfoAsync(event2.Key, "A-1")).Status);
+        Assert.Equal(EventObjectInfo.Free, (await Client.Events.RetrieveObjectInfoAsync(event2.Key, "A-2")).Status);
     }
 }

--- a/SeatsioDotNet.Test/Events/ChangeObjectStatusInBatchTest.cs
+++ b/SeatsioDotNet.Test/Events/ChangeObjectStatusInBatchTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using SeatsioDotNet.Events;
 using Xunit;
 
@@ -7,37 +8,37 @@ namespace SeatsioDotNet.Test.Events;
 public class ChangeObjectStatusInBatchTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
         var chartKey1 = CreateTestChart();
         var chartKey2 = CreateTestChart();
-        var evnt1 = Client.Events.Create(chartKey1);
-        var evnt2 = Client.Events.Create(chartKey2);
+        var evnt1 = await Client.Events.CreateAsync(chartKey1);
+        var evnt2 = await Client.Events.CreateAsync(chartKey2);
 
-        var result = Client.Events.ChangeObjectStatus(new[]
+        var result = await Client.Events.ChangeObjectStatusAsync(new[]
         {
             new StatusChangeRequest(evnt1.Key, new[] {"A-1"}, "lolzor"),
             new StatusChangeRequest(evnt2.Key, new[] {"A-2"}, "lolzor")
         });
 
         Assert.Equal("lolzor", result[0].Objects["A-1"].Status);
-        Assert.Equal("lolzor", Client.Events.RetrieveObjectInfo(evnt1.Key, "A-1").Status);
+        Assert.Equal("lolzor", (await Client.Events.RetrieveObjectInfoAsync(evnt1.Key, "A-1")).Status);
 
         Assert.Equal("lolzor", result[1].Objects["A-2"].Status);
-        Assert.Equal("lolzor", Client.Events.RetrieveObjectInfo(evnt2.Key, "A-2").Status);
+        Assert.Equal("lolzor", (await Client.Events.RetrieveObjectInfoAsync(evnt2.Key, "A-2")).Status);
     }
 
     [Fact]
-    public void ChannelKeys()
+    public async Task ChannelKeys()
     {
         var chartKey = CreateTestChart();
         var channels = new List<Channel>
         {
             new("channelKey1", "channel 1", "#FFFF00", 1, new[] {"A-1"})
         };
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithChannels(channels));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithChannels(channels));
 
-        var result = Client.Events.ChangeObjectStatus(new[]
+        var result = await Client.Events.ChangeObjectStatusAsync(new[]
         {
             new StatusChangeRequest(evnt.Key, new[] {"A-1"}, "lolzor", channelKeys: new[] {"channelKey1"}),
         });
@@ -46,51 +47,50 @@ public class ChangeObjectStatusInBatchTest : SeatsioClientTest
     }
 
     [Fact]
-    public void IgnoreChannels()
+    public async Task IgnoreChannels()
     {
         var chartKey = CreateTestChart();
         var channels = new List<Channel>
         {
             new("channelKey1", "channel 1", "#FFFF00", 1, new[] {"A-1"})
         };
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithChannels(channels));
-            
-        var result = Client.Events.ChangeObjectStatus(new[]
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithChannels(channels));
+
+        var result = await Client.Events.ChangeObjectStatusAsync(new[]
         {
             new StatusChangeRequest(evnt.Key, new[] {"A-1"}, "lolzor", ignoreChannels: true),
         });
 
         Assert.Equal("lolzor", result[0].Objects["A-1"].Status);
     }
-        
+
     [Fact]
-    public void AllowedPreviousStatuses()
+    public async Task AllowedPreviousStatuses()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-            
-        Assert.Throws<SeatsioException>(() =>
+        var evnt = await Client.Events.CreateAsync(chartKey);
+
+        await Assert.ThrowsAsync<SeatsioException>(async () =>
         {
-            Client.Events.ChangeObjectStatus(new[]
+            await Client.Events.ChangeObjectStatusAsync(new[]
             {
-                new StatusChangeRequest(evnt.Key, new[] {"A-1"}, "lolzor", ignoreChannels: true, allowedPreviousStatuses:new []{"someOtherStatus"}),
-            });                
+                new StatusChangeRequest(evnt.Key, new[] {"A-1"}, "lolzor", ignoreChannels: true, allowedPreviousStatuses: new[] {"someOtherStatus"}),
+            });
         });
-            
     }
-        
+
     [Fact]
-    public void RejectedPreviousStatuses()
+    public async Task RejectedPreviousStatuses()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-            
-        Assert.Throws<SeatsioException>(() =>
+        var evnt = await Client.Events.CreateAsync(chartKey);
+
+        await Assert.ThrowsAsync<SeatsioException>(async () =>
         {
-            Client.Events.ChangeObjectStatus(new[]
+            await Client.Events.ChangeObjectStatusAsync(new[]
             {
-                new StatusChangeRequest(evnt.Key, new[] {"A-1"}, "lolzor", ignoreChannels: true, rejectedPreviousStatuses:new []{"free"}),
-            });                
+                new StatusChangeRequest(evnt.Key, new[] {"A-1"}, "lolzor", ignoreChannels: true, rejectedPreviousStatuses: new[] {"free"}),
+            });
         });
     }
 }

--- a/SeatsioDotNet.Test/Events/ChangeObjectStatusTest.cs
+++ b/SeatsioDotNet.Test/Events/ChangeObjectStatusTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using SeatsioDotNet.EventReports;
 using SeatsioDotNet.Events;
@@ -10,16 +11,16 @@ namespace SeatsioDotNet.Test.Events;
 public class ChangeObjectStatusTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var result = Client.Events.ChangeObjectStatus(evnt.Key, new[] {"A-1", "A-2"}, "foo");
+        var result = await Client.Events.ChangeObjectStatusAsync(evnt.Key, new[] {"A-1", "A-2"}, "foo");
 
-        Assert.Equal("foo", Client.Events.RetrieveObjectInfo(evnt.Key, "A-1").Status);
-        Assert.Equal("foo", Client.Events.RetrieveObjectInfo(evnt.Key, "A-2").Status);
-        Assert.Equal(EventObjectInfo.Free, Client.Events.RetrieveObjectInfo(evnt.Key, "A-3").Status);
+        Assert.Equal("foo", (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1")).Status);
+        Assert.Equal("foo", (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-2")).Status);
+        Assert.Equal(EventObjectInfo.Free, (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-3")).Status);
         CustomAssert.ContainsOnly(new[] {"A-1", "A-2"}, result.Objects.Keys);
 
         var reportItem = result.Objects["A-1"];
@@ -42,152 +43,152 @@ public class ChangeObjectStatusTest : SeatsioClientTest
     }
 
     [Fact]
-    public void HoldToken()
+    public async Task HoldToken()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        HoldToken holdToken = Client.HoldTokens.Create();
-        Client.Events.Hold(evnt.Key, new[] {"A-1", "A-2"}, holdToken.Token);
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        HoldToken holdToken = await Client.HoldTokens.CreateAsync();
+        await Client.Events.HoldAsync(evnt.Key, new[] {"A-1", "A-2"}, holdToken.Token);
 
-        Client.Events.ChangeObjectStatus(evnt.Key, new[] {"A-1", "A-2"}, "foo", holdToken.Token);
+        await Client.Events.ChangeObjectStatusAsync(evnt.Key, new[] {"A-1", "A-2"}, "foo", holdToken.Token);
 
-        var objectInfo1 = Client.Events.RetrieveObjectInfo(evnt.Key, "A-1");
+        var objectInfo1 = await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1");
         Assert.Equal("foo", objectInfo1.Status);
         Assert.Null(objectInfo1.HoldToken);
 
-        var objectInfo2 = Client.Events.RetrieveObjectInfo(evnt.Key, "A-2");
+        var objectInfo2 = await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-2");
         Assert.Equal("foo", objectInfo2.Status);
         Assert.Null(objectInfo2.HoldToken);
     }
 
     [Fact]
-    public void OrderId()
+    public async Task OrderId()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        Client.Events.ChangeObjectStatus(evnt.Key, new[] {"A-1", "A-2"}, "foo", null, "order1");
+        await Client.Events.ChangeObjectStatusAsync(evnt.Key, new[] {"A-1", "A-2"}, "foo", null, "order1");
 
-        Assert.Equal("order1", Client.Events.RetrieveObjectInfo(evnt.Key, "A-1").OrderId);
-        Assert.Equal("order1", Client.Events.RetrieveObjectInfo(evnt.Key, "A-2").OrderId);
+        Assert.Equal("order1", (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1")).OrderId);
+        Assert.Equal("order1", (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-2")).OrderId);
     }
 
     [Fact]
-    public void TicketType()
+    public async Task TicketType()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
         ObjectProperties object1 = new ObjectProperties("A-1", "T1");
         ObjectProperties object2 = new ObjectProperties("A-2", "T2");
 
-        Client.Events.ChangeObjectStatus(evnt.Key, new[] {object1, object2}, "foo");
+        await Client.Events.ChangeObjectStatusAsync(evnt.Key, new[] {object1, object2}, "foo");
 
-        var objectInfo1 = Client.Events.RetrieveObjectInfo(evnt.Key, "A-1");
+        var objectInfo1 = await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1");
         Assert.Equal("foo", objectInfo1.Status);
         Assert.Equal("T1", objectInfo1.TicketType);
 
-        var objectInfo2 = Client.Events.RetrieveObjectInfo(evnt.Key, "A-2");
+        var objectInfo2 = await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-2");
         Assert.Equal("foo", objectInfo2.Status);
         Assert.Equal("T2", objectInfo2.TicketType);
     }
 
     [Fact]
-    public void Quantity()
+    public async Task Quantity()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
         ObjectProperties object1 = new ObjectProperties("GA1", 5);
 
-        Client.Events.ChangeObjectStatus(evnt.Key, new[] {object1}, "foo");
+        await Client.Events.ChangeObjectStatusAsync(evnt.Key, new[] {object1}, "foo");
 
-        var objectInfo1 = Client.Events.RetrieveObjectInfo(evnt.Key, "GA1");
+        var objectInfo1 = await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "GA1");
         Assert.Equal(5, objectInfo1.NumBooked);
     }
 
     [Fact]
-    public void ExtraData()
+    public async Task ExtraData()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
         var extraData1 = new Dictionary<string, object> {{"foo", "bar"}};
         ObjectProperties object1 = new ObjectProperties("A-1", extraData1);
         var extraData2 = new Dictionary<string, object> {{"foo", "baz"}};
         ObjectProperties object2 = new ObjectProperties("A-2", extraData2);
 
-        Client.Events.ChangeObjectStatus(evnt.Key, new[] {object1, object2}, "foo");
+        await Client.Events.ChangeObjectStatusAsync(evnt.Key, new[] {object1, object2}, "foo");
 
-        var objectInfo1 = Client.Events.RetrieveObjectInfo(evnt.Key, "A-1");
+        var objectInfo1 = await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1");
         Assert.Equal(extraData1, objectInfo1.ExtraData);
 
-        var objectInfo2 = Client.Events.RetrieveObjectInfo(evnt.Key, "A-2");
+        var objectInfo2 = await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-2");
         Assert.Equal(extraData2, objectInfo2.ExtraData);
     }
 
     [Fact]
-    public void KeepExtraDataTrue()
+    public async Task KeepExtraDataTrue()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
         var extraData = new Dictionary<string, object> {{"foo1", "bar1"}};
-        Client.Events.UpdateExtraData(evnt.Key, "A-1", extraData);
+        await Client.Events.UpdateExtraDataAsync(evnt.Key, "A-1", extraData);
 
-        Client.Events.ChangeObjectStatus(evnt.Key, new[] {"A-1"}, "someStatus", null, null, true);
+        await Client.Events.ChangeObjectStatusAsync(evnt.Key, new[] {"A-1"}, "someStatus", null, null, true);
 
-        Assert.Equal(extraData, Client.Events.RetrieveObjectInfo(evnt.Key, "A-1").ExtraData);
+        Assert.Equal(extraData, (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1")).ExtraData);
     }
 
     [Fact]
-    public void KeepExtraDataFalse()
+    public async Task KeepExtraDataFalse()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
         var extraData = new Dictionary<string, object> {{"foo1", "bar1"}};
-        Client.Events.UpdateExtraData(evnt.Key, "A-1", extraData);
+        await Client.Events.UpdateExtraDataAsync(evnt.Key, "A-1", extraData);
 
-        Client.Events.ChangeObjectStatus(evnt.Key, new[] {"A-1"}, "someStatus", null, null, false);
+        await Client.Events.ChangeObjectStatusAsync(evnt.Key, new[] {"A-1"}, "someStatus", null, null, false);
 
-        Assert.Null(Client.Events.RetrieveObjectInfo(evnt.Key, "A-1").ExtraData);
+        Assert.Null((await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1")).ExtraData);
     }
 
     [Fact]
-    public void NoKeepExtraData()
+    public async Task NoKeepExtraData()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
         var extraData = new Dictionary<string, object> {{"foo1", "bar1"}};
-        Client.Events.UpdateExtraData(evnt.Key, "A-1", extraData);
+        await Client.Events.UpdateExtraDataAsync(evnt.Key, "A-1", extraData);
 
-        Client.Events.ChangeObjectStatus(evnt.Key, new[] {"A-1"}, "someStatus");
+        await Client.Events.ChangeObjectStatusAsync(evnt.Key, new[] {"A-1"}, "someStatus");
 
-        Assert.Null(Client.Events.RetrieveObjectInfo(evnt.Key, "A-1").ExtraData);
+        Assert.Null((await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1")).ExtraData);
     }
-        
+
     [Fact]
-    public void AllowedPreviousStatuses()
+    public async Task AllowedPreviousStatuses()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        Assert.Throws<SeatsioException>(() =>
+        await Assert.ThrowsAsync<SeatsioException>(async () =>
         {
-            Client.Events.ChangeObjectStatus(evnt.Key, new[] {"A-1"}, "someStatus", 
+            await Client.Events.ChangeObjectStatusAsync(evnt.Key, new[] {"A-1"}, "someStatus",
                 null, null, null, null, null,
-                new []{"somePreviousStatus"}
+                new[] {"somePreviousStatus"}
             );
         });
     }
 
     [Fact]
-    public void RejectedPreviousStatuses()
+    public async Task RejectedPreviousStatuses()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        Assert.Throws<SeatsioException>(() =>
+        await Assert.ThrowsAsync<SeatsioException>(async () =>
         {
-            Client.Events.ChangeObjectStatus(evnt.Key, new[] {"A-1"}, "someStatus", 
-                null, null, null, null, null, 
-                null, new []{"free"}
+            await Client.Events.ChangeObjectStatusAsync(evnt.Key, new[] {"A-1"}, "someStatus",
+                null, null, null, null, null,
+                null, new[] {"free"}
             );
         });
     }

--- a/SeatsioDotNet.Test/Events/Channels/AddChannelTest.cs
+++ b/SeatsioDotNet.Test/Events/Channels/AddChannelTest.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using SeatsioDotNet.Events;
 using Xunit;
 
@@ -6,14 +7,14 @@ namespace SeatsioDotNet.Test.Events;
 public class AddChannelTest : SeatsioClientTest
 {
     [Fact]
-    public void AddChannel()
+    public async Task AddChannel()
     {
-        var event1 = Client.Events.Create(CreateTestChart());
+        var event1 = await Client.Events.CreateAsync(CreateTestChart());
 
-        Client.Events.Channels.Add(event1.Key, "channelKey1", "channel 1", "#FFFF98", 1, new[] {"A-1", "A-2"});
-        Client.Events.Channels.Add(event1.Key, "channelKey2", "channel 2", "#FFFF99", 2, new[] {"A-3"});
+        await Client.Events.Channels.AddAsync(event1.Key, "channelKey1", "channel 1", "#FFFF98", 1, new[] {"A-1", "A-2"});
+        await Client.Events.Channels.AddAsync(event1.Key, "channelKey2", "channel 2", "#FFFF99", 2, new[] {"A-3"});
 
-        var retrievedEvent = Client.Events.Retrieve(event1.Key);
+        var retrievedEvent = await Client.Events.RetrieveAsync(event1.Key);
         Assert.Equal(2, retrievedEvent.Channels.Count);
 
         var channel1 = retrievedEvent.Channels[0];
@@ -33,11 +34,11 @@ public class AddChannelTest : SeatsioClientTest
     }
 
     [Fact]
-    public void AddChannels()
+    public async Task AddChannels()
     {
-        var event1 = Client.Events.Create(CreateTestChart());
+        var event1 = await Client.Events.CreateAsync(CreateTestChart());
 
-        Client.Events.Channels.Add(
+        await Client.Events.Channels.AddAsync(
             event1.Key,
             new[]
             {
@@ -46,7 +47,7 @@ public class AddChannelTest : SeatsioClientTest
             }
         );
             
-        var retrievedEvent = Client.Events.Retrieve(event1.Key);
+        var retrievedEvent = await Client.Events.RetrieveAsync(event1.Key);
         Assert.Equal(2, retrievedEvent.Channels.Count);
 
         var channel1 = retrievedEvent.Channels[0];
@@ -66,13 +67,13 @@ public class AddChannelTest : SeatsioClientTest
     }
 
     [Fact]
-    public void IndexIsOptional()
+    public async Task IndexIsOptional()
     {
-        var event1 = Client.Events.Create(CreateTestChart());
+        var event1 = await Client.Events.CreateAsync(CreateTestChart());
 
-        Client.Events.Channels.Add(event1.Key, "channelKey1", "channel 1", "#FFFF98", null, new[] {"A-1", "A-2"});
+        await Client.Events.Channels.AddAsync(event1.Key, "channelKey1", "channel 1", "#FFFF98", null, new[] {"A-1", "A-2"});
 
-        var retrievedEvent = Client.Events.Retrieve(event1.Key);
+        var retrievedEvent = await Client.Events.RetrieveAsync(event1.Key);
         Assert.Equal(1, retrievedEvent.Channels.Count);
 
         var channel1 = retrievedEvent.Channels[0];
@@ -84,13 +85,13 @@ public class AddChannelTest : SeatsioClientTest
     }
 
     [Fact]
-    public void ObjectsAreOptional()
+    public async Task ObjectsAreOptional()
     {
-        var event1 = Client.Events.Create(CreateTestChart());
+        var event1 = await Client.Events.CreateAsync(CreateTestChart());
 
-        Client.Events.Channels.Add(event1.Key, "channelKey1", "channel 1", "#FFFF98", 1, null);
+        await Client.Events.Channels.AddAsync(event1.Key, "channelKey1", "channel 1", "#FFFF98", 1, null);
 
-        var retrievedEvent = Client.Events.Retrieve(event1.Key);
+        var retrievedEvent = await Client.Events.RetrieveAsync(event1.Key);
         Assert.Equal(1, retrievedEvent.Channels.Count);
 
         var channel1 = retrievedEvent.Channels[0];

--- a/SeatsioDotNet.Test/Events/Channels/AddObjectsToChannelTest.cs
+++ b/SeatsioDotNet.Test/Events/Channels/AddObjectsToChannelTest.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Events;
@@ -5,15 +6,15 @@ namespace SeatsioDotNet.Test.Events;
 public class AddObjectsToChannelTest : SeatsioClientTest
 {
     [Fact]
-    public void AddObjectsToChannel()
+    public async Task AddObjectsToChannel()
     {
-        var event1 = Client.Events.Create(CreateTestChart());
-        Client.Events.Channels.Add(event1.Key, "channelKey1", "channel 1", "#FFFF98", 1, new[] {"A-1", "A-2"});
-        Client.Events.Channels.Add(event1.Key, "channelKey2", "channel 2", "#FFFF99", 2, new[] {"A-3", "A-4"});
+        var event1 = await Client.Events.CreateAsync(CreateTestChart());
+        await Client.Events.Channels.AddAsync(event1.Key, "channelKey1", "channel 1", "#FFFF98", 1, new[] {"A-1", "A-2"});
+        await Client.Events.Channels.AddAsync(event1.Key, "channelKey2", "channel 2", "#FFFF99", 2, new[] {"A-3", "A-4"});
 
-        Client.Events.Channels.AddObjects(event1.Key, "channelKey1", new[] {"A-3", "A-4"});
+        await Client.Events.Channels.AddObjectsAsync(event1.Key, "channelKey1", new[] {"A-3", "A-4"});
             
-        var retrievedChannels = Client.Events.Retrieve(event1.Key).Channels;
+        var retrievedChannels = (await Client.Events.RetrieveAsync(event1.Key)).Channels;
         Assert.Equal(new[] {"A-1", "A-2", "A-3", "A-4"}, retrievedChannels[0].Objects);
         Assert.Empty(retrievedChannels[1].Objects);
     }

--- a/SeatsioDotNet.Test/Events/Channels/RemoveChannelTest.cs
+++ b/SeatsioDotNet.Test/Events/Channels/RemoveChannelTest.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Events;
@@ -5,15 +6,15 @@ namespace SeatsioDotNet.Test.Events;
 public class RemoveChannelTest : SeatsioClientTest
 {
     [Fact]
-    public void AddChannel()
+    public async Task AddChannel()
     {
-        var event1 = Client.Events.Create(CreateTestChart());
-        Client.Events.Channels.Add(event1.Key, "channelKey1", "channel 1", "#FFFF98", 1, new[] {"A-1", "A-2"});
-        Client.Events.Channels.Add(event1.Key, "channelKey2", "channel 2", "#FFFF99", 2, new[] {"A-3"});
+        var event1 = await Client.Events.CreateAsync(CreateTestChart());
+        await Client.Events.Channels.AddAsync(event1.Key, "channelKey1", "channel 1", "#FFFF98", 1, new[] {"A-1", "A-2"});
+        await Client.Events.Channels.AddAsync(event1.Key, "channelKey2", "channel 2", "#FFFF99", 2, new[] {"A-3"});
 
-        Client.Events.Channels.Remove(event1.Key, "channelKey2");
+        await Client.Events.Channels.RemoveAsync(event1.Key, "channelKey2");
 
-        var retrievedEvent = Client.Events.Retrieve(event1.Key);
+        var retrievedEvent = await Client.Events.RetrieveAsync(event1.Key);
         Assert.Equal(1, retrievedEvent.Channels.Count);
 
         var channel1 = retrievedEvent.Channels[0];

--- a/SeatsioDotNet.Test/Events/Channels/RemoveObjectsFromChannelTest.cs
+++ b/SeatsioDotNet.Test/Events/Channels/RemoveObjectsFromChannelTest.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Events;
@@ -5,14 +6,14 @@ namespace SeatsioDotNet.Test.Events;
 public class RemoveObjectsFromChannelTest : SeatsioClientTest
 {
     [Fact]
-    public void RemoveObjectsFromChannel()
+    public async Task RemoveObjectsFromChannel()
     {
-        var event1 = Client.Events.Create(CreateTestChart());
-        Client.Events.Channels.Add(event1.Key, "channelKey1", "channel 1", "#FFFF98", 1, new[] {"A-1", "A-2", "A-3", "A-4"});
+        var event1 = await Client.Events.CreateAsync(CreateTestChart());
+        await Client.Events.Channels.AddAsync(event1.Key, "channelKey1", "channel 1", "#FFFF98", 1, new[] {"A-1", "A-2", "A-3", "A-4"});
 
-        Client.Events.Channels.RemoveObjects(event1.Key, "channelKey1", new[] {"A-3", "A-4"});
+        await Client.Events.Channels.RemoveObjectsAsync(event1.Key, "channelKey1", new[] {"A-3", "A-4"});
             
-        var retrievedChannels = Client.Events.Retrieve(event1.Key).Channels;
+        var retrievedChannels = (await Client.Events.RetrieveAsync(event1.Key)).Channels;
         Assert.Equal(new[] {"A-1", "A-2"}, retrievedChannels[0].Objects);
     }
 }

--- a/SeatsioDotNet.Test/Events/Channels/ReplaceChannelsTest.cs
+++ b/SeatsioDotNet.Test/Events/Channels/ReplaceChannelsTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using SeatsioDotNet.Events;
 using Xunit;
 
@@ -8,10 +9,10 @@ namespace SeatsioDotNet.Test.Events;
 public class ReplaceChannelsTest : SeatsioClientTest
 {
     [Fact]
-    public void UpdateChannels()
+    public async Task UpdateChannels()
     {
         var chartKey1 = CreateTestChart();
-        var event1 = Client.Events.Create(chartKey1);
+        var event1 = await Client.Events.CreateAsync(chartKey1);
 
         var channels = new List<Channel>
         {
@@ -19,9 +20,9 @@ public class ReplaceChannelsTest : SeatsioClientTest
             new("channelKey2", "channel 2", "#00FFFF", 2, new String[] { })
         };
 
-        Client.Events.Channels.Replace(event1.Key, channels);
+        await Client.Events.Channels.ReplaceAsync(event1.Key, channels);
 
-        var retrievedEvent = Client.Events.Retrieve(event1.Key);
+        var retrievedEvent = await Client.Events.RetrieveAsync(event1.Key);
         Assert.Equivalent(channels, retrievedEvent.Channels);
     }
 }

--- a/SeatsioDotNet.Test/Events/Channels/UpdateChannelTest.cs
+++ b/SeatsioDotNet.Test/Events/Channels/UpdateChannelTest.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Events;
@@ -5,14 +6,14 @@ namespace SeatsioDotNet.Test.Events;
 public class UpdateChannelTest : SeatsioClientTest
 {
     [Fact]
-    public void UpdateName()
+    public async Task UpdateName()
     {
-        var event1 = Client.Events.Create(CreateTestChart());
-        Client.Events.Channels.Add(event1.Key, "channelKey1", "channel 1", "#FFFF98", 1, new[] {"A-1", "A-2"});
+        var event1 = await Client.Events.CreateAsync(CreateTestChart());
+        await Client.Events.Channels.AddAsync(event1.Key, "channelKey1", "channel 1", "#FFFF98", 1, new[] {"A-1", "A-2"});
 
-        Client.Events.Channels.Update(event1.Key, "channelKey1", "new channel name", null, null);
+        await Client.Events.Channels.UpdateAsync(event1.Key, "channelKey1", "new channel name", null, null);
 
-        var retrievedEvent = Client.Events.Retrieve(event1.Key);
+        var retrievedEvent = await Client.Events.RetrieveAsync(event1.Key);
         Assert.Equal(1, retrievedEvent.Channels.Count);
         var channel1 = retrievedEvent.Channels[0];
         Assert.Equal("channelKey1", channel1.Key);
@@ -23,14 +24,14 @@ public class UpdateChannelTest : SeatsioClientTest
     }
         
     [Fact]
-    public void UpdateColor()
+    public async Task UpdateColor()
     {
-        var event1 = Client.Events.Create(CreateTestChart());
-        Client.Events.Channels.Add(event1.Key, "channelKey1", "channel 1", "#FFFF98", 1, new[] {"A-1", "A-2"});
+        var event1 = await Client.Events.CreateAsync(CreateTestChart());
+        await Client.Events.Channels.AddAsync(event1.Key, "channelKey1", "channel 1", "#FFFF98", 1, new[] {"A-1", "A-2"});
 
-        Client.Events.Channels.Update(event1.Key, "channelKey1", null, "red", null);
+        await Client.Events.Channels.UpdateAsync(event1.Key, "channelKey1", null, "red", null);
 
-        var retrievedEvent = Client.Events.Retrieve(event1.Key);
+        var retrievedEvent = await Client.Events.RetrieveAsync(event1.Key);
         Assert.Equal(1, retrievedEvent.Channels.Count);
         var channel1 = retrievedEvent.Channels[0];
         Assert.Equal("channelKey1", channel1.Key);
@@ -41,14 +42,14 @@ public class UpdateChannelTest : SeatsioClientTest
     }
         
     [Fact]
-    public void UpdateObjects()
+    public async Task UpdateObjects()
     {
-        var event1 = Client.Events.Create(CreateTestChart());
-        Client.Events.Channels.Add(event1.Key, "channelKey1", "channel 1", "#FFFF98", 1, new[] {"A-1", "A-2"});
+        var event1 = await Client.Events.CreateAsync(CreateTestChart());
+        await Client.Events.Channels.AddAsync(event1.Key, "channelKey1", "channel 1", "#FFFF98", 1, new[] {"A-1", "A-2"});
 
-        Client.Events.Channels.Update(event1.Key, "channelKey1", null, null, new []{"B-1"});
+        await Client.Events.Channels.UpdateAsync(event1.Key, "channelKey1", null, null, new []{"B-1"});
 
-        var retrievedEvent = Client.Events.Retrieve(event1.Key);
+        var retrievedEvent = await Client.Events.RetrieveAsync(event1.Key);
         Assert.Equal(1, retrievedEvent.Channels.Count);
         var channel1 = retrievedEvent.Channels[0];
         Assert.Equal("channelKey1", channel1.Key);

--- a/SeatsioDotNet.Test/Events/CreateEventTest.cs
+++ b/SeatsioDotNet.Test/Events/CreateEventTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using SeatsioDotNet.Charts;
 using SeatsioDotNet.Events;
 using Xunit;
@@ -9,11 +10,11 @@ namespace SeatsioDotNet.Test.Events;
 public class CreateEventTest : SeatsioClientTest
 {
     [Fact]
-    public void ChartKeyIsMandatory()
+    public async Task ChartKeyIsMandatory()
     {
         var chartKey = CreateTestChart();
 
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
         Assert.NotNull(evnt.Key);
         Assert.NotEqual(0, evnt.Id);
@@ -27,22 +28,22 @@ public class CreateEventTest : SeatsioClientTest
     }
 
     [Fact]
-    public void EventKeyIsOptional()
+    public async Task EventKeyIsOptional()
     {
         var chartKey = CreateTestChart();
 
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithKey("eventje"));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithKey("eventje"));
 
         Assert.Equal("eventje", evnt.Key);
     }
 
     [Fact]
-    public void TableBookingModeCustomCanBeUsed()
+    public async Task TableBookingModeCustomCanBeUsed()
     {
         var chartKey = CreateTestChartWithTables();
         var tableBookingConfig = TableBookingConfig.Custom(new() {{"T1", "BY_TABLE"}, {"T2", "BY_SEAT"}});
 
-        var evnt = Client.Events.Create(chartKey,
+        var evnt = await Client.Events.CreateAsync(chartKey,
             new CreateEventParams().WithTableBookingConfig(tableBookingConfig));
 
         Assert.NotNull(evnt.Key);
@@ -52,11 +53,11 @@ public class CreateEventTest : SeatsioClientTest
     }
 
     [Fact]
-    public void TableBookingModeInheritCanBeUsed()
+    public async Task TableBookingModeInheritCanBeUsed()
     {
         var chartKey = CreateTestChartWithTables();
 
-        var evnt = Client.Events.Create(chartKey,
+        var evnt = await Client.Events.CreateAsync(chartKey,
             new CreateEventParams().WithTableBookingConfig(TableBookingConfig.Inherit()));
 
         Assert.NotNull(evnt.Key);
@@ -64,7 +65,7 @@ public class CreateEventTest : SeatsioClientTest
     }
 
     [Fact]
-    public void ObjectCategoriesCanBePassedIn()
+    public async Task ObjectCategoriesCanBePassedIn()
     {
         var chartKey = CreateTestChart();
 
@@ -72,45 +73,45 @@ public class CreateEventTest : SeatsioClientTest
         {
             {"A-1", 10L}
         };
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithObjectCategories(objectCategories));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithObjectCategories(objectCategories));
         Assert.Equal(objectCategories, evnt.ObjectCategories);
     }
 
     [Fact]
-    public void CategoriesCanBePassedIn()
+    public async Task CategoriesCanBePassedIn()
     {
         var chartKey = CreateTestChart();
         var eventCategory = new Category("eventCategory", "event-level category", "#AAABBB");
         var categories = new[] {eventCategory};
 
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithCategories(categories));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithCategories(categories));
 
         Assert.Equal(TestChartCategories.Count + categories.Length, evnt.Categories.Count);
         Assert.Contains(eventCategory, evnt.Categories);
     }
 
     [Fact]
-    public void NameCanBePassedIn()
+    public async Task NameCanBePassedIn()
     {
         var chartKey = CreateTestChart();
 
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithName("My event"));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithName("My event"));
 
         Assert.Equal("My event", evnt.Name);
     }
 
     [Fact]
-    public void DateCanBePassedIn()
+    public async Task DateCanBePassedIn()
     {
         var chartKey = CreateTestChart();
 
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithDate(new DateOnly(2022, 1, 10)));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithDate(new DateOnly(2022, 1, 10)));
 
         Assert.Equal(new DateOnly(2022, 1, 10), evnt.Date);
     }
 
     [Fact]
-    public void ChannelsCanBePassedIn()
+    public async Task ChannelsCanBePassedIn()
     {
         var chartKey = CreateTestChart();
         var channels = new List<Channel>
@@ -119,18 +120,18 @@ public class CreateEventTest : SeatsioClientTest
             new("channelKey2", "channel 2", "#00FFFF", 2, new String[] {})
         };
 
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithChannels(channels));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithChannels(channels));
 
         Assert.Equivalent(channels, evnt.Channels);
     }
 
     [Fact]
-    public void ForSaleConfigCanBePassedIn()
+    public async Task ForSaleConfigCanBePassedIn()
     {
         var chartKey = CreateTestChart();
         var forSaleConfig = new ForSaleConfig().WithForSale(false).WithObjects(new []{"A-1"}).WithAreaPlaces(new(){{"GA1", 5}}).WithCategories(new []{"Cat1"});
 
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithForSaleConfig(forSaleConfig));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithForSaleConfig(forSaleConfig));
 
         Assert.Equivalent(forSaleConfig, evnt.ForSaleConfig);
     }

--- a/SeatsioDotNet.Test/Events/CreateEventsTest.cs
+++ b/SeatsioDotNet.Test/Events/CreateEventsTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using SeatsioDotNet.Charts;
 using SeatsioDotNet.Events;
 using Xunit;
@@ -9,7 +10,7 @@ namespace SeatsioDotNet.Test.Events;
 public class CreateEventsTest : SeatsioClientTest
 {
     [Fact]
-    public void MultipleEvents()
+    public async Task MultipleEvents()
     {
         var chartKey = CreateTestChart();
         var eventCreationParams = new[]
@@ -18,13 +19,13 @@ public class CreateEventsTest : SeatsioClientTest
             new CreateEventParams()
         };
 
-        var events = Client.Events.Create(chartKey, eventCreationParams);
+        var events = await Client.Events.CreateAsync(chartKey, eventCreationParams);
 
         Assert.Equal(2, events.Length);
     }
 
     [Fact]
-    public void SingleEvent()
+    public async Task SingleEvent()
     {
         var chartKey = CreateTestChart();
         var eventCreationParams = new[]
@@ -32,7 +33,7 @@ public class CreateEventsTest : SeatsioClientTest
             new CreateEventParams()
         };
 
-        var events = Client.Events.Create(chartKey, eventCreationParams);
+        var events = await Client.Events.CreateAsync(chartKey, eventCreationParams);
 
         Assert.Equal(1, events.Length);
         var e = events[0];
@@ -47,7 +48,7 @@ public class CreateEventsTest : SeatsioClientTest
     }
 
     [Fact]
-    public void EventKeyCanBePassedIn()
+    public async Task EventKeyCanBePassedIn()
     {
         var chartKey = CreateTestChart();
         var eventCreationParams = new[]
@@ -56,14 +57,14 @@ public class CreateEventsTest : SeatsioClientTest
             new CreateEventParams().WithKey("event2")
         };
 
-        var events = Client.Events.Create(chartKey, eventCreationParams);
+        var events = await Client.Events.CreateAsync(chartKey, eventCreationParams);
 
         Assert.Equal("event1", events[0].Key);
         Assert.Equal("event2", events[1].Key);
     }
 
     [Fact]
-    public void TableBookingModesCanBePassedIn()
+    public async Task TableBookingModesCanBePassedIn()
     {
         var chartKey = CreateTestChartWithTables();
         var eventCreationParams = new[]
@@ -74,7 +75,7 @@ public class CreateEventsTest : SeatsioClientTest
                 {{"T1", "BY_SEAT"}, {"T2", "BY_TABLE"}}))
         };
 
-        var events = Client.Events.Create(chartKey, eventCreationParams);
+        var events = await Client.Events.CreateAsync(chartKey, eventCreationParams);
 
         Assert.Equal("CUSTOM", events[0].TableBookingConfig.Mode);
         Assert.Equal(new() {{"T1", "BY_TABLE"}, {"T2", "BY_SEAT"}}, events[0].TableBookingConfig.Tables);
@@ -83,7 +84,7 @@ public class CreateEventsTest : SeatsioClientTest
     }
         
     [Fact]
-    public void ObjectCategoriesCanBePassedIn()
+    public async Task ObjectCategoriesCanBePassedIn()
     {
         var chartKey = CreateTestChart();
         var objectCategories = new Dictionary<string, object>()
@@ -95,13 +96,13 @@ public class CreateEventsTest : SeatsioClientTest
             new CreateEventParams().WithObjectCategories(objectCategories)
         };
 
-        var events = Client.Events.Create(chartKey, eventCreationParams);
+        var events = await Client.Events.CreateAsync(chartKey, eventCreationParams);
 
         Assert.Equal(objectCategories, events[0].ObjectCategories);
     }
 
     [Fact]
-    public void CategoriesCanBePassedIn()
+    public async Task CategoriesCanBePassedIn()
     {
         var chartKey = CreateTestChart();
         var eventCategory = new Category("eventCategory", "event-level category", "#AAABBB");
@@ -110,7 +111,7 @@ public class CreateEventsTest : SeatsioClientTest
         {
             new CreateEventParams().WithCategories(categories)
         };
-        var events = Client.Events.Create(chartKey, eventCreationParams);
+        var events = await Client.Events.CreateAsync(chartKey, eventCreationParams);
 
         Assert.Equal(1, events.Length);
         Assert.Equal(TestChartCategories.Count + categories.Length, events[0].Categories.Count);
@@ -118,7 +119,7 @@ public class CreateEventsTest : SeatsioClientTest
     }
 
     [Fact]
-    public void ErrorOnDuplicateKeys()
+    public async Task ErrorOnDuplicateKeys()
     {
         var chartKey = CreateTestChart();
         var eventCreationParams = new[]
@@ -127,11 +128,11 @@ public class CreateEventsTest : SeatsioClientTest
             new CreateEventParams().WithKey("e1")
         };
 
-        Assert.Throws<SeatsioException>(() => Client.Events.Create(chartKey, eventCreationParams));
+        await Assert.ThrowsAsync<SeatsioException>(async () => await Client.Events.CreateAsync(chartKey, eventCreationParams));
     }
 
     [Fact]
-    public void NameCanBePassedIn()
+    public async Task NameCanBePassedIn()
     {
         var chartKey = CreateTestChart();
         var eventCreationParams = new[]
@@ -139,13 +140,13 @@ public class CreateEventsTest : SeatsioClientTest
             new CreateEventParams().WithName("My event")
         };
 
-        var events = Client.Events.Create(chartKey, eventCreationParams);
+        var events = await Client.Events.CreateAsync(chartKey, eventCreationParams);
 
         Assert.Equal("My event", events[0].Name);
     }
 
     [Fact]
-    public void DateCanBePassedIn()
+    public async Task DateCanBePassedIn()
     {
         var chartKey = CreateTestChart();
         var eventCreationParams = new[]
@@ -153,13 +154,13 @@ public class CreateEventsTest : SeatsioClientTest
             new CreateEventParams().WithDate(new DateOnly(2022, 1, 10))
         };
 
-        var events = Client.Events.Create(chartKey, eventCreationParams);
+        var events = await Client.Events.CreateAsync(chartKey, eventCreationParams);
 
         Assert.Equal(new DateOnly(2022, 1, 10), events[0].Date);
     }    
         
     [Fact]
-    public void ChannelsCanBePassedIn()
+    public async Task ChannelsCanBePassedIn()
     {
         var chartKey = CreateTestChart();
         var channels = new List<Channel>
@@ -168,7 +169,7 @@ public class CreateEventsTest : SeatsioClientTest
             new("channelKey2", "channel 2", "#00FFFF", 2, new String[] {})
         };
 
-        var events = Client.Events.Create(chartKey, new[]
+        var events = await Client.Events.CreateAsync(chartKey, new[]
         {
             new CreateEventParams().WithChannels(channels)
         });
@@ -177,13 +178,13 @@ public class CreateEventsTest : SeatsioClientTest
     }
         
     [Fact]
-    public void ForSaleConfigCanBePassedIn()
+    public async Task ForSaleConfigCanBePassedIn()
     {
         var chartKey = CreateTestChart();
         var forSaleConfig1 = new ForSaleConfig().WithForSale(false).WithObjects(new []{"A-1"}).WithAreaPlaces(new(){{"GA1", 3}}).WithCategories(new []{"Cat1"});
         var forSaleConfig2 = new ForSaleConfig().WithForSale(false).WithObjects(new []{"A-2"}).WithAreaPlaces(new(){{"GA1", 7}}).WithCategories(new []{"Cat1"});
 
-        var events = Client.Events.Create(chartKey, new[]
+        var events = await Client.Events.CreateAsync(chartKey, new[]
         {
             new CreateEventParams().WithForSaleConfig(forSaleConfig1),
             new CreateEventParams().WithForSaleConfig(forSaleConfig2)

--- a/SeatsioDotNet.Test/Events/DeleteEventTest.cs
+++ b/SeatsioDotNet.Test/Events/DeleteEventTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Events;
@@ -6,14 +7,14 @@ namespace SeatsioDotNet.Test.Events;
 public class DeleteEventTest : SeatsioClientTest
 {
     [Fact]
-    public void Delete()
+    public async Task Delete()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        Client.Events.Delete(evnt.Key);
+        await Client.Events.DeleteAsync(evnt.Key);
 
-        Exception ex = Assert.Throws<SeatsioException>(() => Client.Events.Retrieve(evnt.Key));
+        Exception ex = await Assert.ThrowsAsync<SeatsioException>(async () => await Client.Events.RetrieveAsync(evnt.Key));
 
         Assert.Equal("Event not found: " + evnt.Key + ".", ex.Message);
     }

--- a/SeatsioDotNet.Test/Events/HoldObjectsTest.cs
+++ b/SeatsioDotNet.Test/Events/HoldObjectsTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using SeatsioDotNet.EventReports;
 using SeatsioDotNet.Events;
 using SeatsioDotNet.HoldTokens;
@@ -9,94 +10,94 @@ namespace SeatsioDotNet.Test.Events;
 public class HoldObjectsTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        HoldToken holdToken = Client.HoldTokens.Create();
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        HoldToken holdToken = await Client.HoldTokens.CreateAsync();
 
-        var result = Client.Events.Hold(evnt.Key, new[] {"A-1", "A-2"}, holdToken.Token);
+        var result = await Client.Events.HoldAsync(evnt.Key, new[] {"A-1", "A-2"}, holdToken.Token);
 
-        var objectInfo1 = Client.Events.RetrieveObjectInfo(evnt.Key, "A-1");
+        var objectInfo1 = await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1");
         Assert.Equal(EventObjectInfo.Held, objectInfo1.Status);
         Assert.Equal(holdToken.Token, objectInfo1.HoldToken);
 
-        var objectInfo2 = Client.Events.RetrieveObjectInfo(evnt.Key, "A-2");
+        var objectInfo2 = await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-2");
         Assert.Equal(EventObjectInfo.Held, objectInfo2.Status);
         Assert.Equal(holdToken.Token, objectInfo2.HoldToken);
         CustomAssert.ContainsOnly(new[] {"A-1", "A-2"}, result.Objects.Keys);
     }
 
     [Fact]
-    public void OrderId()
+    public async Task OrderId()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        HoldToken holdToken = Client.HoldTokens.Create();
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        HoldToken holdToken = await Client.HoldTokens.CreateAsync();
 
-        Client.Events.Hold(evnt.Key, new[] {"A-1", "A-2"}, holdToken.Token, "order1");
+        await Client.Events.HoldAsync(evnt.Key, new[] {"A-1", "A-2"}, holdToken.Token, "order1");
 
-        Assert.Equal("order1", Client.Events.RetrieveObjectInfo(evnt.Key, "A-1").OrderId);
-        Assert.Equal("order1", Client.Events.RetrieveObjectInfo(evnt.Key, "A-2").OrderId);
+        Assert.Equal("order1", (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1")).OrderId);
+        Assert.Equal("order1", (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-2")).OrderId);
     }
 
     [Fact]
-    public void BestAvailable()
+    public async Task BestAvailable()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        HoldToken holdToken = Client.HoldTokens.Create();
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        HoldToken holdToken = await Client.HoldTokens.CreateAsync();
 
-        var bestAvailableResult = Client.Events.Hold(evnt.Key, new BestAvailable(3), holdToken.Token, "order1");
+        var bestAvailableResult = await Client.Events.HoldAsync(evnt.Key, new BestAvailable(3), holdToken.Token, "order1");
 
         Assert.True(bestAvailableResult.NextToEachOther);
         Assert.Equal(new[] {"A-4", "A-5", "A-6"}, bestAvailableResult.Objects);
-        Assert.Equal("order1", Client.Events.RetrieveObjectInfo(evnt.Key, "A-4").OrderId);
+        Assert.Equal("order1", (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-4")).OrderId);
     }
 
     [Fact]
-    public void KeepExtraData()
+    public async Task KeepExtraData()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
         var extraData = new Dictionary<string, object> {{"foo1", "bar1"}};
-        Client.Events.UpdateExtraData(evnt.Key, "A-1", extraData);
-        HoldToken holdToken = Client.HoldTokens.Create();
+        await Client.Events.UpdateExtraDataAsync(evnt.Key, "A-1", extraData);
+        HoldToken holdToken = await Client.HoldTokens.CreateAsync();
 
-        Client.Events.Hold(evnt.Key, new[] {"A-1"}, holdToken.Token, null, true);
+        await Client.Events.HoldAsync(evnt.Key, new[] {"A-1"}, holdToken.Token, null, true);
 
-        Assert.Equal(extraData, Client.Events.RetrieveObjectInfo(evnt.Key, "A-1").ExtraData);
+        Assert.Equal(extraData, (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1")).ExtraData);
     }
 
     [Fact]
-    public void ChannelKeys()
+    public async Task ChannelKeys()
     {
         var chartKey = CreateTestChart();
         var channels = new List<Channel>
         {
             new("channelKey1", "channel 1", "#FFFF00", 1, new[] {"A-1", "A-2"})
         };
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithChannels(channels));
-        HoldToken holdToken = Client.HoldTokens.Create();
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithChannels(channels));
+        HoldToken holdToken = await Client.HoldTokens.CreateAsync();
 
-        Client.Events.Hold(evnt.Key, new[] {"A-1"}, holdToken.Token, null, true, null, new[] {"channelKey1"});
+        await Client.Events.HoldAsync(evnt.Key, new[] {"A-1"}, holdToken.Token, null, true, null, new[] {"channelKey1"});
 
-        Assert.Equal(EventObjectInfo.Held, Client.Events.RetrieveObjectInfo(evnt.Key, "A-1").Status);
+        Assert.Equal(EventObjectInfo.Held, (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1")).Status);
     }    
         
     [Fact]
-    public void IgnoreChannels()
+    public async Task IgnoreChannels()
     {
         var chartKey = CreateTestChart();
         var channels = new List<Channel>
         {
             new("channelKey1", "channel 1", "#FFFF00", 1, new[] {"A-1", "A-2"})
         };
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithChannels(channels));
-        HoldToken holdToken = Client.HoldTokens.Create();
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithChannels(channels));
+        HoldToken holdToken = await Client.HoldTokens.CreateAsync();
 
-        Client.Events.Hold(evnt.Key, new[] {"A-1"}, holdToken.Token, null, true, true);
+        await Client.Events.HoldAsync(evnt.Key, new[] {"A-1"}, holdToken.Token, null, true, true);
 
-        Assert.Equal(EventObjectInfo.Held, Client.Events.RetrieveObjectInfo(evnt.Key, "A-1").Status);
+        Assert.Equal(EventObjectInfo.Held, (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1")).Status);
     }
 }

--- a/SeatsioDotNet.Test/Events/ListEventsTest.cs
+++ b/SeatsioDotNet.Test/Events/ListEventsTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Events;
@@ -6,27 +7,27 @@ namespace SeatsioDotNet.Test.Events;
 public class ListEventsTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
         var chartKey = CreateTestChart();
-        var event1 = Client.Events.Create(chartKey);
-        var event2 = Client.Events.Create(chartKey);
-        var event3 = Client.Events.Create(chartKey);
+        var event1 = await Client.Events.CreateAsync(chartKey);
+        var event2 = await Client.Events.CreateAsync(chartKey);
+        var event3 = await Client.Events.CreateAsync(chartKey);
 
-        var events = Client.Events.ListAll();
+        var events = await Client.Events.ListAllAsync().ToListAsync();
 
         Assert.Equal(new[] {event3.Key, event2.Key, event1.Key}, events.Select(e => e.Key));
     }
 
     [Fact]
-    public void ListSeasons()
+    public async Task ListSeasons()
     {
         var chartKey = CreateTestChart();
-        var season1 = Client.Seasons.Create(chartKey);
-        var season2 = Client.Seasons.Create(chartKey);
-        var season3 = Client.Seasons.Create(chartKey);
+        var season1 = await Client.Seasons.CreateAsync(chartKey);
+        var season2 = await Client.Seasons.CreateAsync(chartKey).ConfigureAwait(false);
+        var season3 = await Client.Seasons.CreateAsync(chartKey).ConfigureAwait(false);
 
-        var seasons = Client.Events.ListAll();
+        var seasons = Client.Events.ListAllAsync();
 
         Assert.Equal(new[] {true, true, true}, seasons.Select(s => s.IsSeason));
     }

--- a/SeatsioDotNet.Test/Events/ListStatusChangesForObjectTest.cs
+++ b/SeatsioDotNet.Test/Events/ListStatusChangesForObjectTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
 using SeatsioDotNet.Events;
 using Xunit;
 
@@ -7,11 +8,11 @@ namespace SeatsioDotNet.Test.Events;
 public class ListStatusChangesForObjectTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.ChangeObjectStatus(new[]
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.ChangeObjectStatusAsync(new[]
         {
             new StatusChangeRequest(evnt.Key, new[] {"A-1"}, "s1"),
             new StatusChangeRequest(evnt.Key, new[] {"A-1"}, "s2"),
@@ -19,9 +20,9 @@ public class ListStatusChangesForObjectTest : SeatsioClientTest
             new StatusChangeRequest(evnt.Key, new[] {"A-1"}, "s4"),
             new StatusChangeRequest(evnt.Key, new[] {"A-2"}, "s5")
         });
-        WaitForStatusChanges(Client, evnt, 5);
+        await WaitForStatusChanges(Client, evnt, 5);
 
-        var statusChanges = Client.Events.StatusChangesForObject(evnt.Key, "A-1").All();
+        var statusChanges = await Client.Events.StatusChangesForObject(evnt.Key, "A-1").AllAsync().ToListAsync();
 
         Assert.Equal(new[] {"s4", "s3", "s2", "s1"}, statusChanges.Select(s => s.Status));
     }

--- a/SeatsioDotNet.Test/Events/MarkEverythingAsForSaleTest.cs
+++ b/SeatsioDotNet.Test/Events/MarkEverythingAsForSaleTest.cs
@@ -1,18 +1,19 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace SeatsioDotNet.Test.Events;
 
 public class MarkEverythingAsForSaleTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.MarkAsNotForSale(evnt.Key, new[] {"o1", "o2"}, null, new[] {"cat1", "cat2"});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.MarkAsNotForSaleAsync(evnt.Key, new[] {"o1", "o2"}, null, new[] {"cat1", "cat2"});
 
-        Client.Events.MarkEverythingAsForSale(evnt.Key);
+        await Client.Events.MarkEverythingAsForSaleAsync(evnt.Key);
             
-        Assert.Null(Client.Events.Retrieve(evnt.Key).ForSaleConfig);
+        Assert.Null((await Client.Events.RetrieveAsync(evnt.Key)).ForSaleConfig);
     }
 }

--- a/SeatsioDotNet.Test/Events/MarkObjectsAsForSaleTest.cs
+++ b/SeatsioDotNet.Test/Events/MarkObjectsAsForSaleTest.cs
@@ -1,17 +1,18 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace SeatsioDotNet.Test.Events;
 
 public class MarkObjectsAsForSaleTest : SeatsioClientTest
 {
     [Fact]
-    public void ObjectsCandCategories()
+    public async Task ObjectsCandCategories()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.MarkAsForSale(evnt.Key, new[] {"o1", "o2"}, new() {{"GA1", 3}}, new[] {"cat1", "cat2"});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.MarkAsForSaleAsync(evnt.Key, new[] {"o1", "o2"}, new() {{"GA1", 3}}, new[] {"cat1", "cat2"});
 
-        var forSaleConfig = Client.Events.Retrieve(evnt.Key).ForSaleConfig;
+        var forSaleConfig = (await Client.Events.RetrieveAsync(evnt.Key)).ForSaleConfig;
         Assert.True(forSaleConfig.ForSale);
         Assert.Equal(new[] {"o1", "o2"}, forSaleConfig.Objects);
         Assert.Equal(new() {{"GA1", 3}}, forSaleConfig.AreaPlaces);
@@ -19,13 +20,13 @@ public class MarkObjectsAsForSaleTest : SeatsioClientTest
     }   
         
     [Fact]
-    public void Objects()
+    public async Task Objects()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.MarkAsForSale(evnt.Key, new[] {"o1", "o2"}, null, null);
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.MarkAsForSaleAsync(evnt.Key, new[] {"o1", "o2"}, null, null);
 
-        var forSaleConfig = Client.Events.Retrieve(evnt.Key).ForSaleConfig;
+        var forSaleConfig = (await Client.Events.RetrieveAsync(evnt.Key)).ForSaleConfig;
         Assert.True(forSaleConfig.ForSale);
         Assert.Equal(new[] {"o1", "o2"}, forSaleConfig.Objects);
         Assert.Empty(forSaleConfig.AreaPlaces);
@@ -33,13 +34,13 @@ public class MarkObjectsAsForSaleTest : SeatsioClientTest
     }  
         
     [Fact]
-    public void Categories()
+    public async Task Categories()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.MarkAsForSale(evnt.Key, null, null, new[] {"cat1", "cat2"});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.MarkAsForSaleAsync(evnt.Key, null, null, new[] {"cat1", "cat2"});
 
-        var forSaleConfig = Client.Events.Retrieve(evnt.Key).ForSaleConfig;
+        var forSaleConfig = (await Client.Events.RetrieveAsync(evnt.Key)).ForSaleConfig;
         Assert.True(forSaleConfig.ForSale);
         Assert.Empty(forSaleConfig.Objects);
         Assert.Empty(forSaleConfig.AreaPlaces);

--- a/SeatsioDotNet.Test/Events/MarkObjectsAsNotForSaleTest.cs
+++ b/SeatsioDotNet.Test/Events/MarkObjectsAsNotForSaleTest.cs
@@ -1,17 +1,18 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace SeatsioDotNet.Test.Events;
 
 public class MarkObjectsAsNotForSaleTest : SeatsioClientTest
 {
     [Fact]
-    public void ObjectsCandCategories()
+    public async Task ObjectsCandCategories()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.MarkAsNotForSale(evnt.Key, new[] {"o1", "o2"}, new() {{"GA1", 3}}, new[] {"cat1", "cat2"});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.MarkAsNotForSaleAsync(evnt.Key, new[] {"o1", "o2"}, new() {{"GA1", 3}}, new[] {"cat1", "cat2"});
 
-        var forSaleConfig = Client.Events.Retrieve(evnt.Key).ForSaleConfig;
+        var forSaleConfig = (await Client.Events.RetrieveAsync(evnt.Key)).ForSaleConfig;
         Assert.False(forSaleConfig.ForSale);
         Assert.Equal(new[] {"o1", "o2"}, forSaleConfig.Objects);
         Assert.Equal(new() {{"GA1", 3}}, forSaleConfig.AreaPlaces);
@@ -19,13 +20,13 @@ public class MarkObjectsAsNotForSaleTest : SeatsioClientTest
     }   
         
     [Fact]
-    public void Objects()
+    public async Task Objects()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.MarkAsNotForSale(evnt.Key, new[] {"o1", "o2"}, null, null);
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.MarkAsNotForSaleAsync(evnt.Key, new[] {"o1", "o2"}, null, null);
 
-        var forSaleConfig = Client.Events.Retrieve(evnt.Key).ForSaleConfig;
+        var forSaleConfig = (await Client.Events.RetrieveAsync(evnt.Key)).ForSaleConfig;
         Assert.False(forSaleConfig.ForSale);
         Assert.Equal(new[] {"o1", "o2"}, forSaleConfig.Objects);
         Assert.Empty(forSaleConfig.AreaPlaces);
@@ -33,13 +34,13 @@ public class MarkObjectsAsNotForSaleTest : SeatsioClientTest
     }  
         
     [Fact]
-    public void Categories()
+    public async Task Categories()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.MarkAsNotForSale(evnt.Key, null, null, new[] {"cat1", "cat2"});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.MarkAsNotForSaleAsync(evnt.Key, null, null, new[] {"cat1", "cat2"});
 
-        var forSaleConfig = Client.Events.Retrieve(evnt.Key).ForSaleConfig;
+        var forSaleConfig = (await Client.Events.RetrieveAsync(evnt.Key)).ForSaleConfig;
         Assert.False(forSaleConfig.ForSale);
         Assert.Empty(forSaleConfig.Objects);
         Assert.Empty(forSaleConfig.AreaPlaces);

--- a/SeatsioDotNet.Test/Events/OverrideSeasonObjectStatusTest.cs
+++ b/SeatsioDotNet.Test/Events/OverrideSeasonObjectStatusTest.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using SeatsioDotNet.EventReports;
 using Xunit;
 
@@ -6,16 +7,16 @@ namespace SeatsioDotNet.Test.Events
     public class OverrideSeasonObjectStatusTest : SeatsioClientTest
     {
         [Fact]
-        public void Test()
+        public async Task Test()
         {
             var chartKey = CreateTestChart();
-            var season = Client.Seasons.Create(chartKey, null, null, new[] {"event1"});
-            Client.Events.Book(season.Key, new[] {"A-1", "A-2"});
+            var season = await Client.Seasons.CreateAsync(chartKey, null, null, new[] {"event1"});
+            await Client.Events.BookAsync(season.Key, new[] {"A-1", "A-2"});
 
-            Client.Events.OverrideSeasonObjectStatus("event1", new[] {"A-1", "A-2"});
+            await Client.Events.OverrideSeasonObjectStatusAsync("event1", new[] {"A-1", "A-2"});
 
-            Assert.Equal(EventObjectInfo.Free, Client.Events.RetrieveObjectInfo("event1", "A-1").Status);
-            Assert.Equal(EventObjectInfo.Free, Client.Events.RetrieveObjectInfo("event1", "A-2").Status);
+            Assert.Equal(EventObjectInfo.Free, (await Client.Events.RetrieveObjectInfoAsync("event1", "A-1")).Status);
+            Assert.Equal(EventObjectInfo.Free, (await Client.Events.RetrieveObjectInfoAsync("event1", "A-2")).Status);
         }
     }
 }

--- a/SeatsioDotNet.Test/Events/ReleaseObjectsTest.cs
+++ b/SeatsioDotNet.Test/Events/ReleaseObjectsTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using SeatsioDotNet.EventReports;
 using SeatsioDotNet.Events;
 using SeatsioDotNet.HoldTokens;
@@ -9,94 +10,94 @@ namespace SeatsioDotNet.Test.Events;
 public class ReleaseObjectsTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.Book(evnt.Key, new[] {"A-1", "A-2"});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.BookAsync(evnt.Key, new[] {"A-1", "A-2"});
 
-        var result = Client.Events.Release(evnt.Key, new[] {"A-1", "A-2"});
+        var result = await Client.Events.ReleaseAsync(evnt.Key, new[] {"A-1", "A-2"});
 
-        Assert.Equal(EventObjectInfo.Free, Client.Events.RetrieveObjectInfo(evnt.Key, "A-1").Status);
-        Assert.Equal(EventObjectInfo.Free, Client.Events.RetrieveObjectInfo(evnt.Key, "A-2").Status);
+        Assert.Equal(EventObjectInfo.Free, (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1")).Status);
+        Assert.Equal(EventObjectInfo.Free, (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-2")).Status);
         CustomAssert.ContainsOnly(new[] {"A-1", "A-2"}, result.Objects.Keys);
     }
 
     [Fact]
-    public void HoldToken()
+    public async Task HoldToken()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        HoldToken holdToken = Client.HoldTokens.Create();
-        Client.Events.Hold(evnt.Key, new[] {"A-1", "A-2"}, holdToken.Token);
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        HoldToken holdToken = await Client.HoldTokens.CreateAsync();
+        await Client.Events.HoldAsync(evnt.Key, new[] {"A-1", "A-2"}, holdToken.Token);
 
-        Client.Events.Release(evnt.Key, new[] {"A-1", "A-2"}, holdToken.Token);
+        await Client.Events.ReleaseAsync(evnt.Key, new[] {"A-1", "A-2"}, holdToken.Token);
 
-        var objectInfo1 = Client.Events.RetrieveObjectInfo(evnt.Key, "A-1");
+        var objectInfo1 = await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1");
         Assert.Equal(EventObjectInfo.Free, objectInfo1.Status);
         Assert.Null(objectInfo1.HoldToken);
 
-        var objectInfo2 = Client.Events.RetrieveObjectInfo(evnt.Key, "A-2");
+        var objectInfo2 = await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-2");
         Assert.Equal(EventObjectInfo.Free, objectInfo2.Status);
         Assert.Null(objectInfo2.HoldToken);
     }
 
     [Fact]
-    public void OrderId()
+    public async Task OrderId()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        Client.Events.Release(evnt.Key, new[] {"A-1", "A-2"}, null, "order1");
+        await Client.Events.ReleaseAsync(evnt.Key, new[] {"A-1", "A-2"}, null, "order1");
 
-        Assert.Equal("order1", Client.Events.RetrieveObjectInfo(evnt.Key, "A-1").OrderId);
-        Assert.Equal("order1", Client.Events.RetrieveObjectInfo(evnt.Key, "A-2").OrderId);
+        Assert.Equal("order1", (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1")).OrderId);
+        Assert.Equal("order1", (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-2")).OrderId);
     }
 
     [Fact]
-    public void KeepExtraData()
+    public async Task KeepExtraData()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
         var extraData = new Dictionary<string, object> {{"foo1", "bar1"}};
-        Client.Events.Book(evnt.Key, new[] {new ObjectProperties("A-1", extraData)});
+        await Client.Events.BookAsync(evnt.Key, new[] {new ObjectProperties("A-1", extraData)});
 
-        Client.Events.Release(evnt.Key, new[] {"A-1"}, null, null, true);
+        await Client.Events.ReleaseAsync(evnt.Key, new[] {"A-1"}, null, null, true);
 
-        Assert.Equal(extraData, Client.Events.RetrieveObjectInfo(evnt.Key, "A-1").ExtraData);
+        Assert.Equal(extraData, (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1")).ExtraData);
     }
 
     [Fact]
-    public void ChannelKeys()
+    public async Task ChannelKeys()
     {
         var chartKey = CreateTestChart();
         var channels = new List<Channel>
         {
             new("channelKey1", "channel 1", "#FFFF00", 1, new[] {"A-1", "A-2"})
         };
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithChannels(channels));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithChannels(channels));
 
-        Client.Events.Book(evnt.Key, new[] {"A-1"}, null, null, true, null, new[] {"channelKey1"});
+        await Client.Events.BookAsync(evnt.Key, new[] {"A-1"}, null, null, true, null, new[] {"channelKey1"});
 
-        Client.Events.Release(evnt.Key, new[] {"A-1"}, null, null, true, null, new[] {"channelKey1"});
+        await Client.Events.ReleaseAsync(evnt.Key, new[] {"A-1"}, null, null, true, null, new[] {"channelKey1"});
 
-        Assert.Equal(EventObjectInfo.Free, Client.Events.RetrieveObjectInfo(evnt.Key, "A-1").Status);
-    }    
-        
+        Assert.Equal(EventObjectInfo.Free, (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1")).Status);
+    }
+
     [Fact]
-    public void IgnoreChannels()
+    public async Task IgnoreChannels()
     {
         var chartKey = CreateTestChart();
         var channels = new List<Channel>
         {
             new("channelKey1", "channel 1", "#FFFF00", 1, new[] {"A-1", "A-2"})
         };
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithChannels(channels));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithChannels(channels));
 
-        Client.Events.Book(evnt.Key, new[] {"A-1"}, null, null, true, null, new[] {"channelKey1"});
+        await Client.Events.BookAsync(evnt.Key, new[] {"A-1"}, null, null, true, null, new[] {"channelKey1"});
 
-        Client.Events.Release(evnt.Key, new[] {"A-1"}, null, null, true, true);
+        await Client.Events.ReleaseAsync(evnt.Key, new[] {"A-1"}, null, null, true, true);
 
-        Assert.Equal(EventObjectInfo.Free, Client.Events.RetrieveObjectInfo(evnt.Key, "A-1").Status);
+        Assert.Equal(EventObjectInfo.Free, (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1")).Status);
     }
 }

--- a/SeatsioDotNet.Test/Events/RetrieveEventObjectInfoTest.cs
+++ b/SeatsioDotNet.Test/Events/RetrieveEventObjectInfoTest.cs
@@ -1,4 +1,5 @@
-﻿using SeatsioDotNet.EventReports;
+﻿using System.Threading.Tasks;
+using SeatsioDotNet.EventReports;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Events;
@@ -6,12 +7,12 @@ namespace SeatsioDotNet.Test.Events;
 public class RetrieveEventObjectInfoTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var objectInfo = Client.Events.RetrieveObjectInfo(evnt.Key, "A-1");
+        var objectInfo = await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1");
 
         Assert.Equal(EventObjectInfo.Free, objectInfo.Status);
         Assert.True(objectInfo.ForSale);

--- a/SeatsioDotNet.Test/Events/RetrieveEventObjectInfosTest.cs
+++ b/SeatsioDotNet.Test/Events/RetrieveEventObjectInfosTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using SeatsioDotNet.EventReports;
 using Xunit;
 
@@ -7,12 +8,12 @@ namespace SeatsioDotNet.Test.Events;
 public class RetrieveEventObjectInfosTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var objectInfos = Client.Events.RetrieveObjectInfos(evnt.Key, new string[] {"A-1", "A-2"});
+        var objectInfos = await Client.Events.RetrieveObjectInfosAsync(evnt.Key, new string[] {"A-1", "A-2"});
 
         Assert.Equal(EventObjectInfo.Free, objectInfos["A-1"].Status);
         Assert.Equal(EventObjectInfo.Free, objectInfos["A-2"].Status);
@@ -20,14 +21,14 @@ public class RetrieveEventObjectInfosTest : SeatsioClientTest
     }
 
     [Fact]
-    public void Holds()
+    public async Task Holds()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        var holdToken = Client.HoldTokens.Create();
-        Client.Events.Hold(evnt.Key, new string[] {"GA1"}, holdToken.Token);
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        var holdToken = await Client.HoldTokens.CreateAsync();
+        await Client.Events.HoldAsync(evnt.Key, new string[] {"GA1"}, holdToken.Token);
 
-        var objectInfos = Client.Events.RetrieveObjectInfos(evnt.Key, new string[] {"GA1"});
+        var objectInfos = await Client.Events.RetrieveObjectInfosAsync(evnt.Key, new string[] {"GA1"});
 
         Dictionary<string, Dictionary<string, int>> expectedHolds = new Dictionary<string, Dictionary<string, int>>();
         expectedHolds.Add(holdToken.Token, new() {{"NO_TICKET_TYPE", 1}});

--- a/SeatsioDotNet.Test/Events/RetrieveEventTest.cs
+++ b/SeatsioDotNet.Test/Events/RetrieveEventTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Events;
@@ -6,12 +7,12 @@ namespace SeatsioDotNet.Test.Events;
 public class RetrieveEventTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var retrievedEvent = Client.Events.Retrieve(evnt.Key);
+        var retrievedEvent = await Client.Events.RetrieveAsync(evnt.Key);
 
         Assert.NotNull(retrievedEvent.Key);
         Assert.NotEqual(0, retrievedEvent.Id);
@@ -27,15 +28,15 @@ public class RetrieveEventTest : SeatsioClientTest
     }
 
     [Fact]
-    public void RetrieveSeason()
+    public async Task RetrieveSeason()
     {
         var chartKey = CreateTestChart();
 
-        var season = Client.Seasons.Create(chartKey);
-        var partialSeason1 = Client.Seasons.CreatePartialSeason(season.Key);
-        var partialSeason2 = Client.Seasons.CreatePartialSeason(season.Key);
+        var season = await Client.Seasons.CreateAsync(chartKey);
+        var partialSeason1 = await Client.Seasons.CreatePartialSeasonAsync(season.Key);
+        var partialSeason2 = await Client.Seasons.CreatePartialSeasonAsync(season.Key);
 
-        var retrievedSeason = Client.Events.Retrieve(season.Key);
+        var retrievedSeason = await Client.Events.RetrieveAsync(season.Key);
 
         Assert.NotNull(retrievedSeason.Key);
         Assert.NotEqual(0, retrievedSeason.Id);

--- a/SeatsioDotNet.Test/Events/UpdateEventTest.cs
+++ b/SeatsioDotNet.Test/Events/UpdateEventTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using SeatsioDotNet.Charts;
 using SeatsioDotNet.Events;
 using Xunit;
@@ -9,43 +10,43 @@ namespace SeatsioDotNet.Test.Events;
 public class UpdateEventTest : SeatsioClientTest
 {
     [Fact]
-    public void UpdateChartKey()
+    public async Task UpdateChartKey()
     {
         var chartKey1 = CreateTestChart();
         var chartKey2 = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey1);
+        var evnt = await Client.Events.CreateAsync(chartKey1);
 
-        Client.Events.Update(evnt.Key, new UpdateEventParams().WithChartKey(chartKey2));
+        await Client.Events.UpdateAsync(evnt.Key, new UpdateEventParams().WithChartKey(chartKey2));
 
-        var retrievedEvent = Client.Events.Retrieve(evnt.Key);
+        var retrievedEvent = await Client.Events.RetrieveAsync(evnt.Key);
         Assert.Equal(evnt.Key, retrievedEvent.Key);
         Assert.Equal(chartKey2, retrievedEvent.ChartKey);
         CustomAssert.CloseTo(DateTimeOffset.Now, retrievedEvent.UpdatedOn.Value);
     }
 
     [Fact]
-    public void UpdateEventKey()
+    public async Task UpdateEventKey()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        Client.Events.Update(evnt.Key, new UpdateEventParams().WithKey("newKey"));
+        await Client.Events.UpdateAsync(evnt.Key, new UpdateEventParams().WithKey("newKey"));
 
-        var retrievedEvent = Client.Events.Retrieve("newKey");
+        var retrievedEvent = await Client.Events.RetrieveAsync("newKey");
         Assert.Equal("newKey", retrievedEvent.Key);
         Assert.Equal(chartKey, retrievedEvent.ChartKey);
     }
 
     [Fact]
-    public void UpdateTableBookingConfig()
+    public async Task UpdateTableBookingConfig()
     {
         var chartKey = CreateTestChartWithTables();
-        var evnt = Client.Events.Create(chartKey,
+        var evnt = await Client.Events.CreateAsync(chartKey,
             new CreateEventParams().WithTableBookingConfig(TableBookingConfig.Custom(new() {{"T1", "BY_TABLE"}})));
 
-        Client.Events.Update(evnt.Key, new UpdateEventParams().WithTableBookingConfig(TableBookingConfig.Custom(new() {{"T1", "BY_SEAT"}})));
+        await Client.Events.UpdateAsync(evnt.Key, new UpdateEventParams().WithTableBookingConfig(TableBookingConfig.Custom(new() {{"T1", "BY_SEAT"}})));
 
-        var retrievedEvent = Client.Events.Retrieve(evnt.Key);
+        var retrievedEvent = await Client.Events.RetrieveAsync(evnt.Key);
         Assert.Equal(evnt.Key, retrievedEvent.Key);
         Assert.Equal(chartKey, retrievedEvent.ChartKey);
         Assert.Equal("CUSTOM", retrievedEvent.TableBookingConfig.Mode);
@@ -53,104 +54,104 @@ public class UpdateEventTest : SeatsioClientTest
     }
         
     [Fact]
-    public void UpdateObjectCategories()
+    public async Task UpdateObjectCategories()
     {
         var chartKey = CreateTestChart();
         var objectCategories = new Dictionary<string, object>()
         {
             {"A-1", 10L}
         };
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithObjectCategories(objectCategories));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithObjectCategories(objectCategories));
 
         var newObjectCategories = new Dictionary<string, object>()
         {
             {"A-2", 9L}
         };
-        Client.Events.Update(evnt.Key, new UpdateEventParams().WithObjectCategories(newObjectCategories));
+        await Client.Events.UpdateAsync(evnt.Key, new UpdateEventParams().WithObjectCategories(newObjectCategories));
 
-        var retrievedEvent = Client.Events.Retrieve(evnt.Key);
+        var retrievedEvent = await Client.Events.RetrieveAsync(evnt.Key);
         Assert.Equal(newObjectCategories, retrievedEvent.ObjectCategories);
     }
 
     [Fact]
-    public void RemoveObjectCategories()
+    public async Task RemoveObjectCategories()
     {
         var chartKey = CreateTestChart();
         var objectCategories = new Dictionary<string, object>()
         {
             {"A-1", 10L}
         };
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithObjectCategories(objectCategories));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithObjectCategories(objectCategories));
 
-        Client.Events.Update(evnt.Key, new UpdateEventParams().WithObjectCategories(new Dictionary<string, object>()));
+        await Client.Events.UpdateAsync(evnt.Key, new UpdateEventParams().WithObjectCategories(new Dictionary<string, object>()));
 
-        var retrievedEvent = Client.Events.Retrieve(evnt.Key);
+        var retrievedEvent = await Client.Events.RetrieveAsync(evnt.Key);
         Assert.Null(retrievedEvent.ObjectCategories);
     }
 
     [Fact]
-    public void UpdateCategories()
+    public async Task UpdateCategories()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
         Category eventCategory = new Category("eventCategory", "event-level category", "#AAABBB");
         Category[] categories = new[] {eventCategory};
 
-        Client.Events.Update(evnt.Key, new UpdateEventParams().WithCategories(categories));
+        await Client.Events.UpdateAsync(evnt.Key, new UpdateEventParams().WithCategories(categories));
 
-        var retrievedEvent = Client.Events.Retrieve(evnt.Key);
+        var retrievedEvent = await Client.Events.RetrieveAsync(evnt.Key);
         Assert.Equal(TestChartCategories.Count + categories.Length, retrievedEvent.Categories.Count);
         Assert.Contains(eventCategory, retrievedEvent.Categories);
     }
 
     [Fact]
-    public void RemoveCategories()
+    public async Task RemoveCategories()
     {
         var chartKey = CreateTestChart();
         Category eventCategory = new Category("eventCategory", "event-level category", "#AAABBB");
         Category[] categories = new[] {eventCategory};
 
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithCategories(categories));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithCategories(categories));
 
-        Client.Events.Update(evnt.Key, new UpdateEventParams().WithCategories(new Category[] {}));
+        await Client.Events.UpdateAsync(evnt.Key, new UpdateEventParams().WithCategories(new Category[] {}));
 
-        var retrievedEvent = Client.Events.Retrieve(evnt.Key);
+        var retrievedEvent = await Client.Events.RetrieveAsync(evnt.Key);
         Assert.Equal(TestChartCategories.Count, retrievedEvent.Categories.Count);
         Assert.DoesNotContain(eventCategory, retrievedEvent.Categories);
     }
 
     [Fact]
-    public void UpdateName()
+    public async Task UpdateName()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithName("An event"));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithName("An event"));
 
-        Client.Events.Update(evnt.Key, new UpdateEventParams().WithName("Another event"));
+        await Client.Events.UpdateAsync(evnt.Key, new UpdateEventParams().WithName("Another event"));
 
-        var retrievedEvent = Client.Events.Retrieve(evnt.Key);
+        var retrievedEvent = await Client.Events.RetrieveAsync(evnt.Key);
         Assert.Equal("Another event", retrievedEvent.Name);
     }  
         
     [Fact]
-    public void UpdateDate()
+    public async Task UpdateDate()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithName("An event"));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithName("An event"));
 
-        Client.Events.Update(evnt.Key, new UpdateEventParams().WithDate(new DateOnly(2022, 1, 10)));
+        await Client.Events.UpdateAsync(evnt.Key, new UpdateEventParams().WithDate(new DateOnly(2022, 1, 10)));
 
-        var retrievedEvent = Client.Events.Retrieve(evnt.Key);
+        var retrievedEvent = await Client.Events.RetrieveAsync(evnt.Key);
         Assert.Equal(new DateOnly(2022, 1, 10), retrievedEvent.Date);
     }
         
     [Fact]
-    public void UpdateIsInThePast()
+    public async Task UpdateIsInThePast()
     {
         var chartKey = CreateTestChart();
-        Client.Seasons.Create(chartKey, eventKeys: new[] {"event1"});
+        await Client.Seasons.CreateAsync(chartKey, eventKeys: new[] {"event1"});
 
-        Client.Events.Update("event1", new UpdateEventParams().WithIsInThePast(true));
-        var retrievedEvent1 = Client.Events.Retrieve("event1");
+        await Client.Events.UpdateAsync("event1", new UpdateEventParams().WithIsInThePast(true));
+        var retrievedEvent1 = await Client.Events.RetrieveAsync("event1");
         Assert.True(retrievedEvent1.IsInThePast);
     }
 }

--- a/SeatsioDotNet.Test/Events/UpdateExtraDataTest.cs
+++ b/SeatsioDotNet.Test/Events/UpdateExtraDataTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Events;
@@ -6,14 +7,14 @@ namespace SeatsioDotNet.Test.Events;
 public class UpdateExtraDataTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
         var extraData = new Dictionary<string, object> {{"foo", "bar"}};
 
-        Client.Events.UpdateExtraData(evnt.Key, "A-1", extraData);
+        await Client.Events.UpdateExtraDataAsync(evnt.Key, "A-1", extraData);
 
-        Assert.Equal(extraData, Client.Events.RetrieveObjectInfo(evnt.Key, "A-1").ExtraData);
+        Assert.Equal(extraData, (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1")).ExtraData);
     }
 }

--- a/SeatsioDotNet.Test/Events/UpdateExtraDatasTest.cs
+++ b/SeatsioDotNet.Test/Events/UpdateExtraDatasTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Events;
@@ -6,17 +7,17 @@ namespace SeatsioDotNet.Test.Events;
 public class UpdateExtraDatasTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt =await  Client.Events.CreateAsync(chartKey);
         var extraData1 = new Dictionary<string, object> {{"foo1", "bar1"}};
         var extraData2 = new Dictionary<string, object> {{"foo2", "bar2"}};
         var extraDatas = new Dictionary<string, Dictionary<string, object>> {{"A-1", extraData1}, {"A-2", extraData2}};
             
-        Client.Events.UpdateExtraDatas(evnt.Key, extraDatas);
+        await Client.Events.UpdateExtraDatasAsync(evnt.Key, extraDatas);
 
-        Assert.Equal(extraData1, Client.Events.RetrieveObjectInfo(evnt.Key, "A-1").ExtraData);
-        Assert.Equal(extraData2, Client.Events.RetrieveObjectInfo(evnt.Key, "A-2").ExtraData);
+        Assert.Equal(extraData1, (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-1")).ExtraData);
+        Assert.Equal(extraData2, (await Client.Events.RetrieveObjectInfoAsync(evnt.Key, "A-2")).ExtraData);
     }
 }

--- a/SeatsioDotNet.Test/Events/UseSeasonObjectStatusTest.cs
+++ b/SeatsioDotNet.Test/Events/UseSeasonObjectStatusTest.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using SeatsioDotNet.EventReports;
 using Xunit;
 
@@ -6,17 +7,17 @@ namespace SeatsioDotNet.Test.Events
     public class UseSeasonObjectStatusTest : SeatsioClientTest
     {
         [Fact]
-        public void Test()
+        public async Task Test()
         {
             var chartKey = CreateTestChart();
-            var season = Client.Seasons.Create(chartKey, null, null, new[] {"event1"});
-            Client.Events.Book(season.Key, new[] {"A-1", "A-2"});
-            Client.Events.OverrideSeasonObjectStatus("event1", new[] {"A-1", "A-2"});
+            var season = await Client.Seasons.CreateAsync(chartKey, null, null, new[] {"event1"});
+            await Client.Events.BookAsync(season.Key, new[] {"A-1", "A-2"});
+            await Client.Events.OverrideSeasonObjectStatusAsync("event1", new[] {"A-1", "A-2"});
             
-            Client.Events.UseSeasonObjectStatus("event1", new[] {"A-1", "A-2"});
+            await Client.Events.UseSeasonObjectStatusAsync("event1", new[] {"A-1", "A-2"});
 
-            Assert.Equal(EventObjectInfo.Booked, Client.Events.RetrieveObjectInfo("event1", "A-1").Status);
-            Assert.Equal(EventObjectInfo.Booked, Client.Events.RetrieveObjectInfo("event1", "A-2").Status);
+            Assert.Equal(EventObjectInfo.Booked, (await Client.Events.RetrieveObjectInfoAsync("event1", "A-1")).Status);
+            Assert.Equal(EventObjectInfo.Booked, (await Client.Events.RetrieveObjectInfoAsync("event1", "A-2")).Status);
         }
     }
 }

--- a/SeatsioDotNet.Test/HoldTokens/CreateHoldTokenTest.cs
+++ b/SeatsioDotNet.Test/HoldTokens/CreateHoldTokenTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Events;
@@ -6,9 +7,9 @@ namespace SeatsioDotNet.Test.Events;
 public class CreateHoldTokenTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var holdToken = Client.HoldTokens.Create();
+        var holdToken = await Client.HoldTokens.CreateAsync();
             
         Assert.NotNull(holdToken.Token);
         CustomAssert.CloseTo(DateTimeOffset.Now.AddMinutes(15), holdToken.ExpiresAt);
@@ -16,9 +17,9 @@ public class CreateHoldTokenTest : SeatsioClientTest
     }   
         
     [Fact]
-    public void ExpiresInMinutes()
+    public async Task ExpiresInMinutes()
     {
-        var holdToken = Client.HoldTokens.Create(5);
+        var holdToken = await Client.HoldTokens.CreateAsync(5);
             
         Assert.NotNull(holdToken.Token);
         CustomAssert.CloseTo(DateTimeOffset.Now.AddMinutes(5), holdToken.ExpiresAt);

--- a/SeatsioDotNet.Test/HoldTokens/RetrieveHoldTokenTest.cs
+++ b/SeatsioDotNet.Test/HoldTokens/RetrieveHoldTokenTest.cs
@@ -1,15 +1,16 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace SeatsioDotNet.Test.Events;
 
 public class RetrieveHoldTokenTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var holdToken = Client.HoldTokens.Create();
+        var holdToken = await Client.HoldTokens.CreateAsync();
             
-        var retrievedHoldToken = Client.HoldTokens.Retrieve(holdToken.Token);
+        var retrievedHoldToken = await Client.HoldTokens.RetrieveAsync(holdToken.Token);
             
         Assert.Equal(holdToken.Token, retrievedHoldToken.Token);
         Assert.Equal(holdToken.ExpiresAt, retrievedHoldToken.ExpiresAt);

--- a/SeatsioDotNet.Test/HoldTokens/UpdateHoldTokenExpirationDateTest.cs
+++ b/SeatsioDotNet.Test/HoldTokens/UpdateHoldTokenExpirationDateTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Events;
@@ -6,11 +7,11 @@ namespace SeatsioDotNet.Test.Events;
 public class UpdateHoldTokenExpirationDateTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var holdToken = Client.HoldTokens.Create();
+        var holdToken = await Client.HoldTokens.CreateAsync();
 
-        var updatedHoldToken = Client.HoldTokens.ExpiresInMinutes(holdToken.Token, 30);
+        var updatedHoldToken = await Client.HoldTokens.ExpiresInMinutesAsync(holdToken.Token, 30);
             
         Assert.Equal(updatedHoldToken.Token, holdToken.Token);
         CustomAssert.CloseTo(DateTimeOffset.Now.AddMinutes(30), updatedHoldToken.ExpiresAt);

--- a/SeatsioDotNet.Test/Reports/Charts/ChartReportsSummaryTest.cs
+++ b/SeatsioDotNet.Test/Reports/Charts/ChartReportsSummaryTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using SeatsioDotNet.Reports.Charts;
 using Xunit;
 using static SeatsioDotNet.Reports.Charts.ChartReports.Version;
@@ -15,28 +16,28 @@ public class ChartReportsSummaryTest : SeatsioClientTest
         {
             yield return new object[]
             {
-                (Action<SeatsioClient, string>) ((_, _) => { }),
-                (Func<SeatsioClient, string, Dictionary<string, ChartReportSummaryItem>>) ((client, chartKey) =>
-                    client.ChartReports.SummaryByObjectType(chartKey))
+                (Func<SeatsioClient, string, Task>) ((_, _) => Task.CompletedTask),
+                (Func<SeatsioClient, string, Task<Dictionary<string, ChartReportSummaryItem>>>) ((client, chartKey) =>
+                    client.ChartReports.SummaryByObjectTypeAsync(chartKey))
             };
             yield return new object[]
             {
-                (Action<SeatsioClient, string>) (CreateDraftChart),
-                (Func<SeatsioClient, string, Dictionary<string, ChartReportSummaryItem>>) ((client, chartKey) =>
-                    client.ChartReports.SummaryByObjectType(chartKey, version: Draft))
+                (Func<SeatsioClient, string, Task>) (CreateDraftChart),
+                (Func<SeatsioClient, string, Task<Dictionary<string, ChartReportSummaryItem>>>) ((client, chartKey) =>
+                    client.ChartReports.SummaryByObjectTypeAsync(chartKey, version: Draft))
             };
         }
     }
 
     [Theory]
     [MemberData(nameof(SummaryByObjectTypeTestCases), MemberType = typeof(ChartReportsSummaryTest))]
-    public void SummaryByObjectType(Action<SeatsioClient, string> updateChart,
-        Func<SeatsioClient, string, Dictionary<string, ChartReportSummaryItem>> getReport)
+    public async Task SummaryByObjectType(Func<SeatsioClient, string,Task> updateChart,
+        Func<SeatsioClient, string, Task<Dictionary<string, ChartReportSummaryItem>>> getReport)
     {
         var chartKey = CreateTestChart();
-        updateChart(Client, chartKey);
+        await updateChart(Client, chartKey);
 
-        var report = getReport(Client, chartKey);
+        var report = await getReport(Client, chartKey);
 
         Assert.Equal(32, report["seat"].Count);
         Assert.Equal(new() {{NoSection, 32}}, report["seat"].bySection);
@@ -57,15 +58,15 @@ public class ChartReportsSummaryTest : SeatsioClientTest
         {
             yield return new object[]
             {
-                (Action<SeatsioClient, string>) ((_, _) => { }),
-                (Func<SeatsioClient, string, Dictionary<string, ChartReportSummaryItem>>) ((client, chartKey) =>
-                    client.ChartReports.SummaryByObjectType(chartKey, bookWholeTablesMode: "true"))
+                (Func<SeatsioClient, string,Task>) ((_, _) => Task.CompletedTask),
+                (Func<SeatsioClient, string,Task<Dictionary<string, ChartReportSummaryItem>>>) ((client, chartKey) =>
+                    client.ChartReports.SummaryByObjectTypeAsync(chartKey, bookWholeTablesMode: "true"))
             };
             yield return new object[]
             {
-                (Action<SeatsioClient, string>) (CreateDraftChart),
-                (Func<SeatsioClient, string, Dictionary<string, ChartReportSummaryItem>>) ((client, chartKey) =>
-                    client.ChartReports.SummaryByObjectType(chartKey, bookWholeTablesMode: "true", version: Draft))
+                (Func<SeatsioClient, string,Task>) (CreateDraftChart),
+                (Func<SeatsioClient, string, Task<Dictionary<string, ChartReportSummaryItem>>>) ((client, chartKey) =>
+                    client.ChartReports.SummaryByObjectTypeAsync(chartKey, bookWholeTablesMode: "true", version: Draft))
             };
         }
     }
@@ -73,13 +74,13 @@ public class ChartReportsSummaryTest : SeatsioClientTest
     [Theory]
     [MemberData(nameof(SummaryByObjectType_BookWholeTablesTrueTestCases),
         MemberType = typeof(ChartReportsSummaryTest))]
-    public void SummaryByObjectType_BookWholeTablesTrue(Action<SeatsioClient, string> updateChart,
-        Func<SeatsioClient, string, Dictionary<string, ChartReportSummaryItem>> getReport)
+    public async Task SummaryByObjectType_BookWholeTablesTrue(Func<SeatsioClient, string, Task> updateChart,
+        Func<SeatsioClient, string, Task<Dictionary<string, ChartReportSummaryItem>>> getReport)
     {
         var chartKey = CreateTestChartWithTables();
-        updateChart(Client, chartKey);
+        await updateChart(Client, chartKey);
 
-        var report = getReport(Client, chartKey);
+        var report = await getReport(Client, chartKey);
 
         Assert.Equal(0, report["seat"].Count);
         Assert.Equal(2, report["table"].Count);
@@ -91,28 +92,28 @@ public class ChartReportsSummaryTest : SeatsioClientTest
         {
             yield return new object[]
             {
-                (Action<SeatsioClient, string>) ((_, _) => { }),
-                (Func<SeatsioClient, string, Dictionary<string, ChartReportSummaryItem>>) ((client, chartKey) =>
-                    client.ChartReports.SummaryByCategoryKey(chartKey))
+                (Func<SeatsioClient, string,Task>) ((_, _) => Task.CompletedTask),
+                (Func<SeatsioClient, string, Task<Dictionary<string, ChartReportSummaryItem>>>) ((client, chartKey) =>
+                    client.ChartReports.SummaryByCategoryKeyAsync(chartKey))
             };
             yield return new object[]
             {
-                (Action<SeatsioClient, string>) (CreateDraftChart),
-                (Func<SeatsioClient, string, Dictionary<string, ChartReportSummaryItem>>) ((client, chartKey) =>
-                    client.ChartReports.SummaryByCategoryKey(chartKey, version: Draft))
+                (Func<SeatsioClient, string, Task>) (CreateDraftChart),
+                (Func<SeatsioClient, string, Task<Dictionary<string, ChartReportSummaryItem>>>) ((client, chartKey) =>
+                    client.ChartReports.SummaryByCategoryKeyAsync(chartKey, version: Draft))
             };
         }
     }
 
     [Theory]
     [MemberData(nameof(SummaryByCategoryKeyTestCases), MemberType = typeof(ChartReportsSummaryTest))]
-    public void SummaryByCategoryKey(Action<SeatsioClient, string> updateChart,
-        Func<SeatsioClient, string, Dictionary<string, ChartReportSummaryItem>> getReport)
+    public async Task SummaryByCategoryKey(Func<SeatsioClient, string,Task> updateChart,
+        Func<SeatsioClient, string, Task<Dictionary<string, ChartReportSummaryItem>>> getReport)
     {
         var chartKey = CreateTestChart();
-        updateChart(Client, chartKey);
+        await updateChart(Client, chartKey);
 
-        var report = getReport(Client, chartKey);
+        var report = await getReport(Client, chartKey);
 
         Assert.Equal(116, report["9"].Count);
         Assert.Equal(new() {{NoSection, 116}}, report["9"].bySection);
@@ -129,28 +130,28 @@ public class ChartReportsSummaryTest : SeatsioClientTest
         {
             yield return new object[]
             {
-                (Action<SeatsioClient, string>) ((_, _) => { }),
-                (Func<SeatsioClient, string, Dictionary<string, ChartReportSummaryItem>>) ((client, chartKey) =>
-                    client.ChartReports.SummaryByCategoryLabel(chartKey))
+                (Func<SeatsioClient, string,Task>) ((_, _) => Task.CompletedTask),
+                (Func<SeatsioClient, string, Task<Dictionary<string, ChartReportSummaryItem>>>) ((client, chartKey) =>
+                    client.ChartReports.SummaryByCategoryLabelAsync(chartKey))
             };
             yield return new object[]
             {
-                (Action<SeatsioClient, string>) (CreateDraftChart),
-                (Func<SeatsioClient, string, Dictionary<string, ChartReportSummaryItem>>) ((client, chartKey) =>
-                    client.ChartReports.SummaryByCategoryLabel(chartKey, version: Draft))
+                (Func<SeatsioClient, string,Task>) (CreateDraftChart),
+                (Func<SeatsioClient, string, Task<Dictionary<string, ChartReportSummaryItem>>>) ((client, chartKey) =>
+                    client.ChartReports.SummaryByCategoryLabelAsync(chartKey, version: Draft))
             };
         }
     }
 
     [Theory]
     [MemberData(nameof(SummaryByCategoryLabelTestCases), MemberType = typeof(ChartReportsSummaryTest))]
-    public void SummaryByCategoryLabel(Action<SeatsioClient, string> updateChart,
-        Func<SeatsioClient, string, Dictionary<string, ChartReportSummaryItem>> getReport)
+    public async Task SummaryByCategoryLabel(Func<SeatsioClient, string, Task> updateChart,
+        Func<SeatsioClient, string, Task<Dictionary<string, ChartReportSummaryItem>>> getReport)
     {
         var chartKey = CreateTestChart();
-        updateChart(Client, chartKey);
+        await updateChart(Client, chartKey);
 
-        var report = getReport(Client, chartKey);
+        var report = await getReport(Client, chartKey);
 
         Assert.Equal(116, report["Cat1"].Count);
         Assert.Equal(new() {{NoSection, 116}}, report["Cat1"].bySection);
@@ -168,37 +169,37 @@ public class ChartReportsSummaryTest : SeatsioClientTest
         {
             yield return new object[]
             {
-                (Action<SeatsioClient, string>) ((_, _) => { }),
-                (Func<SeatsioClient, string, Dictionary<string, ChartReportSummaryItem>>) ((client, chartKey) =>
-                    client.ChartReports.SummaryBySection(chartKey))
+                (Func<SeatsioClient, string,Task>) ((_, _) => Task.CompletedTask),
+                (Func<SeatsioClient, string, Task<Dictionary<string, ChartReportSummaryItem>>>) ((client, chartKey) =>
+                    client.ChartReports.SummaryBySectionAsync(chartKey))
             };
             yield return new object[]
             {
-                (Action<SeatsioClient, string>) (CreateDraftChart),
-                (Func<SeatsioClient, string, Dictionary<string, ChartReportSummaryItem>>) ((client, chartKey) =>
-                    client.ChartReports.SummaryBySection(chartKey, version: Draft))
+                (Func<SeatsioClient, string,Task>) (CreateDraftChart),
+                (Func<SeatsioClient, string, Task<Dictionary<string, ChartReportSummaryItem>>>) ((client, chartKey) =>
+                    client.ChartReports.SummaryBySectionAsync(chartKey, version: Draft))
             };
         }
     }
 
     [Theory]
     [MemberData(nameof(SummaryBySectionTestCases), MemberType = typeof(ChartReportsSummaryTest))]
-    public void SummaryBySection(Action<SeatsioClient, string> updateChart,
-        Func<SeatsioClient, string, Dictionary<string, ChartReportSummaryItem>> getReport)
+    public async Task SummaryBySection(Func<SeatsioClient, string, Task> updateChart,
+        Func<SeatsioClient, string, Task<Dictionary<string, ChartReportSummaryItem>>> getReport)
     {
         var chartKey = CreateTestChart();
-        updateChart(Client, chartKey);
+        await updateChart(Client, chartKey);
 
-        var report = getReport(Client, chartKey);
+        var report = await getReport(Client, chartKey);
 
         Assert.Equal(232, report[NoSection].Count);
         Assert.Equal(new() {{"9", 116}, {"10", 116}}, report[NoSection].byCategoryKey);
         Assert.Equal(new() {{"Cat1", 116}, {"Cat2", 116}}, report[NoSection].byCategoryLabel);
     }
 
-    private static void CreateDraftChart(SeatsioClient client, string chartKey)
+    private static async Task CreateDraftChart(SeatsioClient client, string chartKey)
     {
-        client.Events.Create(chartKey);
-        client.Charts.Update(chartKey, "foo");
+        await client.Events.CreateAsync(chartKey);
+        await client.Charts.UpdateAsync(chartKey, "foo");
     }
 }

--- a/SeatsioDotNet.Test/Reports/Charts/ChartReportsTest.cs
+++ b/SeatsioDotNet.Test/Reports/Charts/ChartReportsTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using SeatsioDotNet.ChartReports;
 using SeatsioDotNet.Events;
@@ -15,19 +16,27 @@ public class ChartReportsTest : SeatsioClientTest
     {
         get
         {
-            yield return new object[] { (Action<SeatsioClient, string>)((_, _) => { }), (Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>>)((client, chartKey) => client.ChartReports.ByLabel(chartKey))};
-            yield return new object[] { (Action<SeatsioClient, string>)(CreateDraftChart), (Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>>)((client, chartKey) => client.ChartReports.ByLabel(chartKey, version: Draft))};
+            yield return new object[]
+            {
+                (Func<SeatsioClient, string, Task>) ((_, _) => Task.CompletedTask),
+                (Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>>) ((client, chartKey) => client.ChartReports.ByLabelAsync(chartKey))
+            };
+            yield return new object[]
+            {
+                (Func<SeatsioClient, string, Task>) (CreateDraftChart),
+                (Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>>) ((client, chartKey) => client.ChartReports.ByLabelAsync(chartKey, version: Draft))
+            };
         }
     }
-        
+
     [Theory]
     [MemberData(nameof(ByLabelTestCases), MemberType = typeof(ChartReportsTest))]
-    public void ReportItemProperties(Action<SeatsioClient, string> updateChart, Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>> getReport)
+    public async Task ReportItemProperties(Func<SeatsioClient, string, Task> updateChart, Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>> getReport)
     {
         var chartKey = CreateTestChart();
-        updateChart(Client, chartKey);
+        await updateChart(Client, chartKey);
 
-        var report = getReport(Client, chartKey);
+        var report = await getReport(Client, chartKey);
 
         var reportItem = report["A-1"].First();
         Assert.Equal("A-1", reportItem.Label);
@@ -50,36 +59,45 @@ public class ChartReportsTest : SeatsioClientTest
 
     [Theory]
     [MemberData(nameof(ByLabelTestCases), MemberType = typeof(ChartReportsTest))]
-    public void ReportItemPropertiesForGA(Action<SeatsioClient, string> updateChart, Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>> getReport)
+    public async Task ReportItemPropertiesForGA(Func<SeatsioClient, string,Task> updateChart, Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>> getReport)
     {
         var chartKey = CreateTestChart();
-        updateChart(Client, chartKey);
+        await updateChart(Client, chartKey);
 
-        var report = getReport(Client, chartKey);
+        var report = await getReport(Client, chartKey);
 
         var reportItem = report["GA1"].First();
         Assert.Equal(100, reportItem.Capacity);
         Assert.Equal("generalAdmission", reportItem.ObjectType);
         Assert.False(reportItem.BookAsAWhole);
-    }     
-        
+    }
+
     public static IEnumerable<object[]> ReportItemPropertiesForTableTestCases
     {
         get
         {
-            yield return new object[] { (Action<SeatsioClient, string>)((_, _) => { }), (Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>>)((client, chartKey) => client.ChartReports.ByLabel(chartKey, bookWholeTablesMode: "true"))};
-            yield return new object[] { (Action<SeatsioClient, string>)(CreateDraftChart), (Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>>)((client, chartKey) => client.ChartReports.ByLabel(chartKey, bookWholeTablesMode: "true", version: Draft))};
+            yield return new object[]
+            {
+                (Func<SeatsioClient, string, Task>) ((_, _) => Task.CompletedTask),
+                (Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>>) ((client, chartKey) => client.ChartReports.ByLabelAsync(chartKey, bookWholeTablesMode: "true"))
+            };
+            yield return new object[]
+            {
+                (Func<SeatsioClient, string, Task>) (CreateDraftChart),
+                (Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>>) ((client, chartKey) =>
+                    client.ChartReports.ByLabelAsync(chartKey, bookWholeTablesMode: "true", version: Draft))
+            };
         }
     }
-        
+
     [Theory]
     [MemberData(nameof(ReportItemPropertiesForTableTestCases), MemberType = typeof(ChartReportsTest))]
-    public void ReportItemPropertiesForTable(Action<SeatsioClient, string> updateChart, Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>> getReport)
+    public async Task ReportItemPropertiesForTable(Func<SeatsioClient, string, Task> updateChart, Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>> getReport)
     {
         var chartKey = CreateTestChartWithTables();
-        updateChart(Client, chartKey);
+        await updateChart(Client, chartKey);
 
-        var report = getReport(Client, chartKey);
+        var report = await getReport(Client, chartKey);
 
         var reportItem = report["T1"].First();
         Assert.Equal(6, reportItem.NumSeats);
@@ -88,34 +106,42 @@ public class ChartReportsTest : SeatsioClientTest
 
     [Theory]
     [MemberData(nameof(ByLabelTestCases), MemberType = typeof(ChartReportsTest))]
-    public void ByLabel(Action<SeatsioClient, string> updateChart, Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>> getReport)
+    public async Task ByLabel(Func<SeatsioClient, string, Task> updateChart, Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>> getReport)
     {
         var chartKey = CreateTestChart();
-        updateChart(Client, chartKey);
+        await updateChart(Client, chartKey);
 
-        var report = getReport(Client, chartKey);
+        var report = await getReport(Client, chartKey);
 
         Assert.Single(report["A-1"]);
         Assert.Single(report["A-2"]);
-    }  
-        
+    }
+
     public static IEnumerable<object[]> ByObjectTypeTestCases
     {
         get
         {
-            yield return new object[] { (Action<SeatsioClient, string>)((_, _) => { }), (Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>>)((client, chartKey) => client.ChartReports.ByObjectType(chartKey))};
-            yield return new object[] { (Action<SeatsioClient, string>)(CreateDraftChart), (Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>>)((client, chartKey) => client.ChartReports.ByObjectType(chartKey, version: Draft))};
+            yield return new object[]
+            {
+                (Func<SeatsioClient, string, Task>) ((_, _) => Task.CompletedTask),
+                (Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>>) ((client, chartKey) => client.ChartReports.ByObjectTypeAsync(chartKey))
+            };
+            yield return new object[]
+            {
+                (Func<SeatsioClient, string, Task>) (CreateDraftChart),
+                (Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>>) ((client, chartKey) => client.ChartReports.ByObjectTypeAsync(chartKey, version: Draft))
+            };
         }
     }
-        
+
     [Theory]
     [MemberData(nameof(ByObjectTypeTestCases), MemberType = typeof(ChartReportsTest))]
-    public void ByObjectType(Action<SeatsioClient, string> updateChart, Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>> getReport)
+    public async Task ByObjectType(Func<SeatsioClient, string, Task> updateChart, Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>> getReport)
     {
         var chartKey = CreateTestChart();
-        updateChart(Client, chartKey);
+        await updateChart(Client, chartKey);
 
-        var report = getReport(Client, chartKey);
+        var report = await getReport(Client, chartKey);
 
         Assert.Equal(32, report["seat"].Count());
         Assert.Equal(2, report["generalAdmission"].Count());
@@ -127,19 +153,27 @@ public class ChartReportsTest : SeatsioClientTest
     {
         get
         {
-            yield return new object[] { (Action<SeatsioClient, string>)((_, _) => { }), (Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>>)((client, chartKey) => client.ChartReports.ByCategoryKey(chartKey))};
-            yield return new object[] { (Action<SeatsioClient, string>)(CreateDraftChart), (Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>>)((client, chartKey) => client.ChartReports.ByCategoryKey(chartKey, version: Draft))};
+            yield return new object[]
+            {
+                (Func<SeatsioClient, string, Task>) ((_, _) => Task.CompletedTask),
+                (Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>>) ((client, chartKey) => client.ChartReports.ByCategoryKeyAsync(chartKey))
+            };
+            yield return new object[]
+            {
+                (Func<SeatsioClient, string, Task>) (CreateDraftChart),
+                (Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>>) ((client, chartKey) => client.ChartReports.ByCategoryKeyAsync(chartKey, version: Draft))
+            };
         }
     }
-        
+
     [Theory]
     [MemberData(nameof(ByCategoryKeyTestCases), MemberType = typeof(ChartReportsTest))]
-    public void ByCategoryKey(Action<SeatsioClient, string> updateChart, Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>> getReport)
+    public async Task ByCategoryKey(Func<SeatsioClient, string, Task> updateChart, Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>> getReport)
     {
         var chartKey = CreateTestChart();
-        updateChart(Client, chartKey);
+        await updateChart(Client, chartKey);
 
-        var report = getReport(Client, chartKey);
+        var report = await getReport(Client, chartKey);
         Assert.Equal(4, report.Count);
         Assert.Equal(17, report["9"].Count());
         Assert.Equal(17, report["10"].Count());
@@ -151,43 +185,59 @@ public class ChartReportsTest : SeatsioClientTest
     {
         get
         {
-            yield return new object[] { (Action<SeatsioClient, string>)((_, _) => { }), (Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>>)((client, chartKey) => client.ChartReports.ByCategoryLabel(chartKey))};
-            yield return new object[] { (Action<SeatsioClient, string>)(CreateDraftChart), (Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>>)((client, chartKey) => client.ChartReports.ByCategoryLabel(chartKey, version: Draft))};
+            yield return new object[]
+            {
+                (Func<SeatsioClient, string, Task>) ((_, _) => Task.CompletedTask),
+                (Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>>) ((client, chartKey) => client.ChartReports.ByCategoryLabelAsync(chartKey))
+            };
+            yield return new object[]
+            {
+                (Func<SeatsioClient, string, Task>) (CreateDraftChart),
+                (Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>>) ((client, chartKey) => client.ChartReports.ByCategoryLabelAsync(chartKey, version: Draft))
+            };
         }
     }
-        
+
     [Theory]
     [MemberData(nameof(ByCategoryLabelTestCases), MemberType = typeof(ChartReportsTest))]
-    public void ByCategoryLabel(Action<SeatsioClient, string> updateChart, Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>> getReport)
+    public async Task ByCategoryLabel(Func<SeatsioClient, string, Task> updateChart, Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>> getReport)
     {
         var chartKey = CreateTestChart();
-        updateChart(Client, chartKey);
+        await updateChart(Client, chartKey);
 
-        var report = getReport(Client, chartKey);
+        var report = await getReport(Client, chartKey);
         Assert.Equal(4, report.Count);
         Assert.Equal(17, report["Cat1"].Count());
         Assert.Equal(17, report["Cat2"].Count());
         Assert.Empty(report["Cat3"]);
         Assert.Empty(report["NO_CATEGORY"]);
-    }  
-        
+    }
+
     public static IEnumerable<object[]> BySectionTestCases
     {
         get
         {
-            yield return new object[] { (Action<SeatsioClient, string>)((_, _) => { }), (Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>>)((client, chartKey) => client.ChartReports.BySection(chartKey))};
-            yield return new object[] { (Action<SeatsioClient, string>)(CreateDraftChart), (Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>>)((client, chartKey) => client.ChartReports.BySection(chartKey, version: Draft))};
+            yield return new object[]
+            {
+                (Func<SeatsioClient, string, Task>) ((_, _) => Task.CompletedTask),
+                (Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>>) ((client, chartKey) => client.ChartReports.BySectionAsync(chartKey))
+            };
+            yield return new object[]
+            {
+                (Func<SeatsioClient, string, Task>) (CreateDraftChart),
+                (Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>>) ((client, chartKey) => client.ChartReports.BySectionAsync(chartKey, version: Draft))
+            };
         }
     }
-        
+
     [Theory]
     [MemberData(nameof(BySectionTestCases), MemberType = typeof(ChartReportsTest))]
-    public void BySection(Action<SeatsioClient, string> updateChart, Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>> getReport)
+    public async Task BySection(Func<SeatsioClient, string, Task> updateChart, Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>> getReport)
     {
         var chartKey = CreateTestChartWithSections();
-        updateChart(Client, chartKey);
+        await updateChart(Client, chartKey);
 
-        var report = getReport(Client, chartKey);
+        var report = await getReport(Client, chartKey);
         Assert.Equal(3, report.Count);
         Assert.Equal(36, report["Section A"].Count());
         Assert.Equal(35, report["Section B"].Count());
@@ -196,82 +246,109 @@ public class ChartReportsTest : SeatsioClientTest
 
     [Theory]
     [MemberData(nameof(ByLabelTestCases), MemberType = typeof(ChartReportsTest))]
-    public void ByLabel_BookWholeTablesModeNull(Action<SeatsioClient, string> updateChart, Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>> getReport)
+    public async Task ByLabel_BookWholeTablesModeNull(Func<SeatsioClient, string, Task> updateChart, Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>> getReport)
     {
         var chartKey = CreateTestChartWithTables();
-        updateChart(Client, chartKey);
+        await updateChart(Client, chartKey);
 
-        var report = getReport(Client, chartKey);
+        var report = await getReport(Client, chartKey);
 
-        CustomAssert.ContainsOnly(new [] {"T1-1", "T1-2", "T1-3", "T1-4", "T1-5", "T1-6", "T2-1", "T2-2", "T2-3", "T2-4", "T2-5", "T2-6", "T1", "T2"}, report.Keys);
+        CustomAssert.ContainsOnly(new[] {"T1-1", "T1-2", "T1-3", "T1-4", "T1-5", "T1-6", "T2-1", "T2-2", "T2-3", "T2-4", "T2-5", "T2-6", "T1", "T2"}, report.Keys);
     }
 
     public static IEnumerable<object[]> ByLabel_BookWholeTablesModeChartTestCases
     {
         get
         {
-            yield return new object[] { (Action<SeatsioClient, string>)((_, _) => { }), (Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>>)((client, chartKey) => client.ChartReports.ByLabel(chartKey, bookWholeTablesMode: "chart"))};
-            yield return new object[] { (Action<SeatsioClient, string>)(CreateDraftChart), (Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>>)((client, chartKey) => client.ChartReports.ByLabel(chartKey, bookWholeTablesMode: "chart", version: Draft))};
+            yield return new object[]
+            {
+                (Func<SeatsioClient, string, Task>) ((_, _) => Task.CompletedTask),
+                (Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>>) ((client, chartKey) => client.ChartReports.ByLabelAsync(chartKey, bookWholeTablesMode: "chart"))
+            };
+            yield return new object[]
+            {
+                (Func<SeatsioClient, string, Task>) (CreateDraftChart),
+                (Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>>) ((client, chartKey) =>
+                    client.ChartReports.ByLabelAsync(chartKey, bookWholeTablesMode: "chart", version: Draft))
+            };
         }
     }
-        
+
     [Theory]
     [MemberData(nameof(ByLabel_BookWholeTablesModeChartTestCases), MemberType = typeof(ChartReportsTest))]
-    public void ByLabel_BookWholeTablesModeChart(Action<SeatsioClient, string> updateChart, Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>> getReport)
+    public async Task ByLabel_BookWholeTablesModeChart(Func<SeatsioClient, string, Task> updateChart, Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>> getReport)
     {
         var chartKey = CreateTestChartWithTables();
-        updateChart(Client, chartKey);
+        await updateChart(Client, chartKey);
 
-        var report = getReport(Client, chartKey);
+        var report = await getReport(Client, chartKey);
 
-        CustomAssert.ContainsOnly(new [] {"T1-1", "T1-2", "T1-3", "T1-4", "T1-5", "T1-6", "T2"}, report.Keys);
+        CustomAssert.ContainsOnly(new[] {"T1-1", "T1-2", "T1-3", "T1-4", "T1-5", "T1-6", "T2"}, report.Keys);
     }
 
     public static IEnumerable<object[]> ByLabel_BookWholeTablesModeTrueTestCases
     {
         get
         {
-            yield return new object[] { (Action<SeatsioClient, string>)((_, _) => { }), (Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>>)((client, chartKey) => client.ChartReports.ByLabel(chartKey, bookWholeTablesMode: "true"))};
-            yield return new object[] { (Action<SeatsioClient, string>)(CreateDraftChart), (Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>>)((client, chartKey) => client.ChartReports.ByLabel(chartKey, bookWholeTablesMode: "true", version: Draft))};
+            yield return new object[]
+            {
+                (Func<SeatsioClient, string, Task>) ((_, _) => Task.CompletedTask),
+                (Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>>) ((client, chartKey) => client.ChartReports.ByLabelAsync(chartKey, bookWholeTablesMode: "true"))
+            };
+            yield return new object[]
+            {
+                (Func<SeatsioClient, string, Task>) (CreateDraftChart),
+                (Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>>) ((client, chartKey) =>
+                    client.ChartReports.ByLabelAsync(chartKey, bookWholeTablesMode: "true", version: Draft))
+            };
         }
     }
-        
+
     [Theory]
     [MemberData(nameof(ByLabel_BookWholeTablesModeTrueTestCases), MemberType = typeof(ChartReportsTest))]
-    public void ByLabel_BookWholeTablesModeTrue(Action<SeatsioClient, string> updateChart, Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>> getReport)
+    public async Task ByLabel_BookWholeTablesModeTrue(Func<SeatsioClient, string, Task> updateChart, Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>> getReport)
     {
         var chartKey = CreateTestChartWithTables();
-        updateChart(Client, chartKey);
+        await updateChart(Client, chartKey);
 
-        var report = Client.ChartReports.ByLabel(chartKey, "true");
+        var report = await Client.ChartReports.ByLabelAsync(chartKey, "true");
 
-        CustomAssert.ContainsOnly(new [] {"T1", "T2"}, report.Keys);
+        CustomAssert.ContainsOnly(new[] {"T1", "T2"}, report.Keys);
     }
 
     public static IEnumerable<object[]> ByLabel_BookWholeTablesModeFalseTestCases
     {
         get
         {
-            yield return new object[] { (Action<SeatsioClient, string>)((_, _) => { }), (Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>>)((client, chartKey) => client.ChartReports.ByLabel(chartKey, bookWholeTablesMode: "false"))};
-            yield return new object[] { (Action<SeatsioClient, string>)(CreateDraftChart), (Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>>)((client, chartKey) => client.ChartReports.ByLabel(chartKey, bookWholeTablesMode: "false", version: Draft))};
+            yield return new object[]
+            {
+                (Func<SeatsioClient, string, Task>) ((_, _) => Task.CompletedTask),
+                (Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>>) ((client, chartKey) => client.ChartReports.ByLabelAsync(chartKey, bookWholeTablesMode: "false"))
+            };
+            yield return new object[]
+            {
+                (Func<SeatsioClient, string, Task>) (CreateDraftChart),
+                (Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>>) ((client, chartKey) =>
+                    client.ChartReports.ByLabelAsync(chartKey, bookWholeTablesMode: "false", version: Draft))
+            };
         }
     }
-        
+
     [Theory]
     [MemberData(nameof(ByLabel_BookWholeTablesModeFalseTestCases), MemberType = typeof(ChartReportsTest))]
-    public void ByLabel_BookWholeTablesModeFalse(Action<SeatsioClient, string> updateChart, Func<SeatsioClient, string, Dictionary<string, IEnumerable<ChartObjectInfo>>> getReport)
+    public async Task ByLabel_BookWholeTablesModeFalse(Func<SeatsioClient, string, Task> updateChart, Func<SeatsioClient, string, Task<Dictionary<string, IEnumerable<ChartObjectInfo>>>> getReport)
     {
         var chartKey = CreateTestChartWithTables();
-        updateChart(Client, chartKey);
+        await updateChart(Client, chartKey);
 
-        var report = getReport(Client, chartKey);
+        var report = await getReport(Client, chartKey);
 
-        CustomAssert.ContainsOnly(new [] {"T1-1", "T1-2", "T1-3", "T1-4", "T1-5", "T1-6", "T2-1", "T2-2", "T2-3", "T2-4", "T2-5", "T2-6"}, report.Keys);
+        CustomAssert.ContainsOnly(new[] {"T1-1", "T1-2", "T1-3", "T1-4", "T1-5", "T1-6", "T2-1", "T2-2", "T2-3", "T2-4", "T2-5", "T2-6"}, report.Keys);
     }
-        
-    private static void CreateDraftChart(SeatsioClient client, string chartKey)
+
+    private static async Task CreateDraftChart(SeatsioClient client, string chartKey)
     {
-        client.Events.Create(chartKey);
-        client.Charts.Update(chartKey, "foo");
+        await client.Events.CreateAsync(chartKey);
+        await client.Charts.UpdateAsync(chartKey, "foo");
     }
 }

--- a/SeatsioDotNet.Test/Reports/Events/EventReportsDeepSummaryTest.cs
+++ b/SeatsioDotNet.Test/Reports/Events/EventReportsDeepSummaryTest.cs
@@ -1,4 +1,5 @@
-﻿using SeatsioDotNet.Events;
+﻿using System.Threading.Tasks;
+using SeatsioDotNet.Events;
 using Xunit;
 using static SeatsioDotNet.EventReports.EventObjectInfo;
 
@@ -7,13 +8,13 @@ namespace SeatsioDotNet.Test.Reports.Events;
 public class EventReportsDeepSummaryTest : SeatsioClientTest
 {
     [Fact]
-    public void DeepSummaryByStatus()
+    public async Task DeepSummaryByStatus()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.Book(evnt.Key, new[] {new ObjectProperties("A-1")});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.BookAsync(evnt.Key, new[] {new ObjectProperties("A-1")});
 
-        var report = Client.EventReports.DeepSummaryByStatus(evnt.Key);
+        var report = await Client.EventReports.DeepSummaryByStatusAsync(evnt.Key);
 
         Assert.Equal(1, report[Booked].Count);
         Assert.Equal(1, report[Booked].bySection[NoSection].Count);
@@ -21,12 +22,12 @@ public class EventReportsDeepSummaryTest : SeatsioClientTest
     }
 
     [Fact]
-    public void DeepSummaryByObjectType()
+    public async Task DeepSummaryByObjectType()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var report = Client.EventReports.DeepSummaryByObjectType(evnt.Key);
+        var report = await Client.EventReports.DeepSummaryByObjectTypeAsync(evnt.Key);
 
         Assert.Equal(32, report["seat"].Count);
         Assert.Equal(32, report["seat"].bySection[NoSection].Count);
@@ -34,13 +35,13 @@ public class EventReportsDeepSummaryTest : SeatsioClientTest
     }
 
     [Fact]
-    public void DeepSummaryByCategoryKey()
+    public async Task DeepSummaryByCategoryKey()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.Book(evnt.Key, new[] {new ObjectProperties("A-1")});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.BookAsync(evnt.Key, new[] {new ObjectProperties("A-1")});
 
-        var report = Client.EventReports.DeepSummaryByCategoryKey(evnt.Key);
+        var report = await Client.EventReports.DeepSummaryByCategoryKeyAsync(evnt.Key);
 
         Assert.Equal(116, report["9"].Count);
         Assert.Equal(116, report["9"].bySection[NoSection].Count);
@@ -48,13 +49,13 @@ public class EventReportsDeepSummaryTest : SeatsioClientTest
     }
 
     [Fact]
-    public void DeepSummaryByCategoryLabel()
+    public async Task DeepSummaryByCategoryLabel()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.Book(evnt.Key, new[] {new ObjectProperties("A-1")});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.BookAsync(evnt.Key, new[] {new ObjectProperties("A-1")});
 
-        var report = Client.EventReports.DeepSummaryByCategoryLabel(evnt.Key);
+        var report = await Client.EventReports.DeepSummaryByCategoryLabelAsync(evnt.Key);
 
         Assert.Equal(116, report["Cat1"].Count);
         Assert.Equal(116, report["Cat1"].bySection[NoSection].Count);
@@ -62,13 +63,13 @@ public class EventReportsDeepSummaryTest : SeatsioClientTest
     }
 
     [Fact]
-    public void DeepSummaryBySection()
+    public async Task DeepSummaryBySection()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.Book(evnt.Key, new[] {new ObjectProperties("A-1")});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.BookAsync(evnt.Key, new[] {new ObjectProperties("A-1")});
 
-        var report = Client.EventReports.DeepSummaryBySection(evnt.Key);
+        var report = await Client.EventReports.DeepSummaryBySectionAsync(evnt.Key);
 
         Assert.Equal(232, report[NoSection].Count);
         Assert.Equal(116, report[NoSection].byCategoryLabel["Cat1"].Count);
@@ -76,13 +77,13 @@ public class EventReportsDeepSummaryTest : SeatsioClientTest
     }
 
     [Fact]
-    public void DeepSummaryByAvailability()
+    public async Task DeepSummaryByAvailability()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.Book(evnt.Key, new[] {new ObjectProperties("A-1")});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.BookAsync(evnt.Key, new[] {new ObjectProperties("A-1")});
 
-        var report = Client.EventReports.DeepSummaryByAvailability(evnt.Key);
+        var report = await Client.EventReports.DeepSummaryByAvailabilityAsync(evnt.Key);
 
         Assert.Equal(1, report[NotAvailable].Count);
         Assert.Equal(1, report[NotAvailable].byCategoryLabel["Cat1"].Count);
@@ -90,13 +91,13 @@ public class EventReportsDeepSummaryTest : SeatsioClientTest
     }
 
     [Fact]
-    public void DeepSummaryByAvailabilityReason()
+    public async Task DeepSummaryByAvailabilityReason()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.Book(evnt.Key, new[] {new ObjectProperties("A-1")});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.BookAsync(evnt.Key, new[] {new ObjectProperties("A-1")});
 
-        var report = Client.EventReports.DeepSummaryByAvailabilityReason(evnt.Key);
+        var report = await Client.EventReports.DeepSummaryByAvailabilityReasonAsync(evnt.Key);
 
         Assert.Equal(1, report[Booked].Count);
         Assert.Equal(1, report[Booked].byCategoryLabel["Cat1"].Count);
@@ -104,13 +105,13 @@ public class EventReportsDeepSummaryTest : SeatsioClientTest
     }
 
     [Fact]
-    public void DeepSummaryByChannel()
+    public async Task DeepSummaryByChannel()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.Book(evnt.Key, new[] {new ObjectProperties("A-1")});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.BookAsync(evnt.Key, new[] {new ObjectProperties("A-1")});
 
-        var report = Client.EventReports.DeepSummaryByChannel(evnt.Key);
+        var report = await Client.EventReports.DeepSummaryByChannelAsync(evnt.Key);
 
         Assert.Equal(232, report[NoChannel].Count);
         Assert.Equal(116, report[NoChannel].byCategoryLabel["Cat1"].Count);

--- a/SeatsioDotNet.Test/Reports/Events/EventReportsSummaryTest.cs
+++ b/SeatsioDotNet.Test/Reports/Events/EventReportsSummaryTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using SeatsioDotNet.Events;
 using Xunit;
 using static SeatsioDotNet.EventReports.EventObjectInfo;
@@ -8,13 +9,13 @@ namespace SeatsioDotNet.Test.Reports.Events;
 public class EventReportsSummaryTest : SeatsioClientTest
 {
     [Fact]
-    public void SummaryByStatus()
+    public async Task SummaryByStatus()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.Book(evnt.Key, new[] {new ObjectProperties("A-1")});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.BookAsync(evnt.Key, new[] {new ObjectProperties("A-1")});
 
-        var report = Client.EventReports.SummaryByStatus(evnt.Key);
+        var report = await Client.EventReports.SummaryByStatusAsync(evnt.Key);
 
         Assert.Equal(1, report[Booked].Count);
         Assert.Equal(new() {{NoSection, 1}}, report[Booked].bySection);
@@ -32,12 +33,12 @@ public class EventReportsSummaryTest : SeatsioClientTest
     }
 
     [Fact]
-    public void SummaryByObjectType()
+    public async Task SummaryByObjectType()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var report = Client.EventReports.SummaryByObjectType(evnt.Key);
+        var report = await Client.EventReports.SummaryByObjectTypeAsync(evnt.Key);
 
         Assert.Equal(32, report["seat"].Count);
         Assert.Equal(new() {{NoSection, 32}}, report["seat"].bySection);
@@ -55,13 +56,13 @@ public class EventReportsSummaryTest : SeatsioClientTest
     }
 
     [Fact]
-    public void SummaryByCategoryKey()
+    public async Task SummaryByCategoryKey()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.Book(evnt.Key, new[] {new ObjectProperties("A-1")});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.BookAsync(evnt.Key, new[] {new ObjectProperties("A-1")});
 
-        var report = Client.EventReports.SummaryByCategoryKey(evnt.Key);
+        var report = await Client.EventReports.SummaryByCategoryKeyAsync(evnt.Key);
 
         Assert.Equal(116, report["9"].Count);
         Assert.Equal(new() {{NoSection, 116}}, report["9"].bySection);
@@ -79,13 +80,13 @@ public class EventReportsSummaryTest : SeatsioClientTest
     }
 
     [Fact]
-    public void SummaryByCategoryLabel()
+    public async Task SummaryByCategoryLabel()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.Book(evnt.Key, new[] {new ObjectProperties("A-1")});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.BookAsync(evnt.Key, new[] {new ObjectProperties("A-1")});
 
-        var report = Client.EventReports.SummaryByCategoryLabel(evnt.Key);
+        var report = await Client.EventReports.SummaryByCategoryLabeAsync(evnt.Key);
 
         Assert.Equal(116, report["Cat1"].Count);
         Assert.Equal(new() {{NoSection, 116}}, report["Cat1"].bySection);
@@ -104,13 +105,13 @@ public class EventReportsSummaryTest : SeatsioClientTest
     }
 
     [Fact]
-    public void SummaryBySection()
+    public async Task SummaryBySection()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.Book(evnt.Key, new[] {new ObjectProperties("A-1")});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.BookAsync(evnt.Key, new[] {new ObjectProperties("A-1")});
 
-        var report = Client.EventReports.SummaryBySection(evnt.Key);
+        var report = await Client.EventReports.SummaryBySectionAsync(evnt.Key);
 
         Assert.Equal(232, report[NoSection].Count);
         Assert.Equal(new() {{Booked, 1}, {Free, 231}}, report[NoSection].byStatus);
@@ -121,13 +122,13 @@ public class EventReportsSummaryTest : SeatsioClientTest
     }
 
     [Fact]
-    public void SummaryByAvailability()
+    public async Task SummaryByAvailability()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.Book(evnt.Key, new[] {new ObjectProperties("A-1")});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.BookAsync(evnt.Key, new[] {new ObjectProperties("A-1")});
 
-        var report = Client.EventReports.SummaryByAvailability(evnt.Key);
+        var report = await Client.EventReports.SummaryByAvailabilityAsync(evnt.Key);
 
         Assert.Equal(231, report[Available].Count);
         Assert.Equal(new() {{NoSection, 231}}, report[Available].bySection);
@@ -143,13 +144,13 @@ public class EventReportsSummaryTest : SeatsioClientTest
     }
 
     [Fact]
-    public void SummaryByAvailabilityReason()
+    public async Task SummaryByAvailabilityReason()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.Book(evnt.Key, new[] {new ObjectProperties("A-1")});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.BookAsync(evnt.Key, new[] {new ObjectProperties("A-1")});
 
-        var report = Client.EventReports.SummaryByAvailabilityReason(evnt.Key);
+        var report = await Client.EventReports.SummaryByAvailabilityReasonAsync(evnt.Key);
 
         Assert.Equal(231, report[Available].Count);
         Assert.Equal(new() {{NoSection, 231}}, report[Available].bySection);
@@ -165,16 +166,16 @@ public class EventReportsSummaryTest : SeatsioClientTest
     }
 
     [Fact]
-    public void SummaryByChannel()
+    public async Task SummaryByChannel()
     {
         var chartKey = CreateTestChart();
         var channels = new List<Channel>
         {
             new("channelKey1", "channel 1", "#FFFF00", 1, new[] {"A-1", "A-2"})
         };
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithChannels(channels));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithChannels(channels));
 
-        var report = Client.EventReports.SummaryByChannel(evnt.Key);
+        var report = await Client.EventReports.SummaryByChannelAsync(evnt.Key);
 
         Assert.Equal(230, report[NoChannel].Count);
         Assert.Equal(new() {{NoSection, 230}}, report[NoChannel].bySection);

--- a/SeatsioDotNet.Test/Reports/Events/EventReportsTest.cs
+++ b/SeatsioDotNet.Test/Reports/Events/EventReportsTest.cs
@@ -295,7 +295,7 @@ public class EventReportsTest : SeatsioClientTest
         var chartKey = CreateTestChart();
         var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var report = await Client.EventReports.BySection(evnt.Key, NoSection);
+        var report = await Client.EventReports.BySectionAsync(evnt.Key, NoSection);
 
         Assert.Equal(34, report.Count());
     }

--- a/SeatsioDotNet.Test/Reports/Events/EventReportsTest.cs
+++ b/SeatsioDotNet.Test/Reports/Events/EventReportsTest.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using SeatsioDotNet.Events;
 using Xunit;
@@ -10,18 +11,18 @@ namespace SeatsioDotNet.Test.Reports.Events;
 public class EventReportsTest : SeatsioClientTest
 {
     [Fact]
-    public void ReportItemProperties()
+    public async Task ReportItemProperties()
     {
         var chartKey = CreateTestChart();
         var channels = new List<Channel>
         {
             new("channelKey1", "channel 1", "#FFFF00", 1, new[] {"A-1", "A-2"})
         };
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithChannels(channels));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithChannels(channels));
         var extraData = new Dictionary<string, object> {{"foo", "bar"}};
-        Client.Events.Book(evnt.Key, new[] {new ObjectProperties("A-1", "ticketType1", extraData)}, null, "order1", null, true);
+        await Client.Events.BookAsync(evnt.Key, new[] {new ObjectProperties("A-1", "ticketType1", extraData)}, null, "order1", null, true);
 
-        var report = Client.EventReports.ByLabel(evnt.Key);
+        var report = await Client.EventReports.ByLabelAsync(evnt.Key);
 
         var reportItem = report["A-1"].First();
         Assert.Equal("A-1", reportItem.Label);
@@ -49,7 +50,7 @@ public class EventReportsTest : SeatsioClientTest
         Assert.Equal("channelKey1", reportItem.Channel);
         Assert.Null(reportItem.BookAsAWhole);
         Assert.NotNull(reportItem.DistanceToFocalPoint);
-            
+
         var gaItem = report["GA1"].First();
         Assert.True(gaItem.VariableOccupancy);
         Assert.Equal(1, gaItem.MinOccupancy);
@@ -57,29 +58,29 @@ public class EventReportsTest : SeatsioClientTest
     }
 
     [Fact]
-    public void HoldToken()
+    public async Task HoldToken()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        var holdToken = Client.HoldTokens.Create();
-        Client.Events.Hold(evnt.Key, new[] {"A-1"}, holdToken.Token);
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        var holdToken = await Client.HoldTokens.CreateAsync();
+        await Client.Events.HoldAsync(evnt.Key, new[] {"A-1"}, holdToken.Token);
 
-        var report = Client.EventReports.ByLabel(evnt.Key);
+        var report = await Client.EventReports.ByLabelAsync(evnt.Key);
 
         var reportItem = report["A-1"].First();
         Assert.Equal(holdToken.Token, reportItem.HoldToken);
     }
 
     [Fact]
-    public void ReportItemPropertiesForGA()
+    public async Task ReportItemPropertiesForGA()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.Book(evnt.Key, new[] {new ObjectProperties("GA1", 5)});
-        var holdToken = Client.HoldTokens.Create();
-        Client.Events.Hold(evnt.Key, new[] {new ObjectProperties("GA1", 3)}, holdToken.Token);
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.BookAsync(evnt.Key, new[] {new ObjectProperties("GA1", 5)});
+        var holdToken = await Client.HoldTokens.CreateAsync();
+        await Client.Events.HoldAsync(evnt.Key, new[] {new ObjectProperties("GA1", 3)}, holdToken.Token);
 
-        var report = Client.EventReports.ByLabel(evnt.Key);
+        var report = await Client.EventReports.ByLabelAsync(evnt.Key);
 
         var reportItem = report["GA1"].First();
         Assert.Equal(5, reportItem.NumBooked);
@@ -92,15 +93,15 @@ public class EventReportsTest : SeatsioClientTest
         Assert.Null(reportItem.HasRestrictedView);
         Assert.Null(reportItem.DisplayedObjectType);
         Assert.False(reportItem.BookAsAWhole);
-    }   
-        
+    }
+
     [Fact]
-    public void ReportItemPropertiesForTable()
+    public async Task ReportItemPropertiesForTable()
     {
         var chartKey = CreateTestChartWithTables();
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithTableBookingConfig(TableBookingConfig.AllByTable()));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithTableBookingConfig(TableBookingConfig.AllByTable()));
 
-        var report = Client.EventReports.ByLabel(evnt.Key);
+        var report = await Client.EventReports.ByLabelAsync(evnt.Key);
 
         var reportItem = report["T1"].First();
         Assert.Equal(6, reportItem.NumSeats);
@@ -108,14 +109,14 @@ public class EventReportsTest : SeatsioClientTest
     }
 
     [Fact]
-    public void ByStatus()
+    public async Task ByStatus()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.ChangeObjectStatus(evnt.Key, new[] {"A-1", "A-2"}, "lolzor");
-        Client.Events.ChangeObjectStatus(evnt.Key, new[] {"A-3"}, Booked);
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.ChangeObjectStatusAsync(evnt.Key, new[] {"A-1", "A-2"}, "lolzor");
+        await Client.Events.ChangeObjectStatusAsync(evnt.Key, new[] {"A-3"}, Booked);
 
-        var report = Client.EventReports.ByStatus(evnt.Key);
+        var report = await Client.EventReports.ByStatusAsync(evnt.Key);
 
         Assert.Equal(2, report["lolzor"].Count());
         Assert.Single(report[Booked]);
@@ -123,46 +124,46 @@ public class EventReportsTest : SeatsioClientTest
     }
 
     [Fact]
-    public void ByStatusEmptyChart()
+    public async Task ByStatusEmptyChart()
     {
-        var chartKey = Client.Charts.Create().Key;
-        var evnt = Client.Events.Create(chartKey);
+        var chartKey = (await Client.Charts.CreateAsync()).Key;
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var report = Client.EventReports.ByStatus(evnt.Key);
+        var report = await Client.EventReports.ByStatusAsync(evnt.Key);
 
         Assert.Empty(report);
     }
 
     [Fact]
-    public void BySpecificStatus()
+    public async Task BySpecificStatus()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.ChangeObjectStatus(evnt.Key, new[] {"A-1", "A-2"}, "lolzor");
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.ChangeObjectStatusAsync(evnt.Key, new[] {"A-1", "A-2"}, "lolzor");
 
-        var report = Client.EventReports.ByStatus(evnt.Key, "lolzor");
+        var report = await Client.EventReports.ByStatusAsync(evnt.Key, "lolzor");
 
         Assert.Equal(2, report.Count());
     }
 
     [Fact]
-    public void BySpecificNonExistingStatus()
+    public async Task BySpecificNonExistingStatus()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var report = Client.EventReports.ByStatus(evnt.Key, "lolzor");
+        var report = await Client.EventReports.ByStatusAsync(evnt.Key, "lolzor");
 
         Assert.Empty(report);
     }
-        
+
     [Fact]
-    public void ByObjectType()
+    public async Task ByObjectType()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var report = Client.EventReports.ByObjectType(evnt.Key);
+        var report = await Client.EventReports.ByObjectTypeAsync(evnt.Key);
 
         Assert.Equal(32, report["seat"].Count());
         Assert.Equal(2, report["generalAdmission"].Count());
@@ -171,94 +172,94 @@ public class EventReportsTest : SeatsioClientTest
     }
 
     [Fact]
-    public void BySpecificObjectType()
+    public async Task BySpecificObjectType()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var report = Client.EventReports.ByObjectType(evnt.Key, "seat");
+        var report = await Client.EventReports.ByObjectTypeAsync(evnt.Key, "seat");
 
         Assert.Equal(32, report.Count());
     }
 
     [Fact]
-    public void ByCategoryLabel()
+    public async Task ByCategoryLabel()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var report = Client.EventReports.ByCategoryLabel(evnt.Key);
+        var report = await Client.EventReports.ByCategoryLabelAsync(evnt.Key);
 
         Assert.Equal(17, report["Cat1"].Count());
         Assert.Equal(17, report["Cat2"].Count());
     }
 
     [Fact]
-    public void BySpecificCategoryLabel()
+    public async Task BySpecificCategoryLabel()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var report = Client.EventReports.ByCategoryLabel(evnt.Key, "Cat1");
+        var report = await Client.EventReports.ByCategoryLabelAsync(evnt.Key, "Cat1");
 
         Assert.Equal(17, report.Count());
     }
 
     [Fact]
-    public void ByCategoryKey()
+    public async Task ByCategoryKey()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var report = Client.EventReports.ByCategoryKey(evnt.Key);
+        var report = await Client.EventReports.ByCategoryKeyAsync(evnt.Key);
 
         Assert.Equal(17, report["9"].Count());
         Assert.Equal(17, report["10"].Count());
     }
 
     [Fact]
-    public void BySpecificCategoryKey()
+    public async Task BySpecificCategoryKey()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var report = Client.EventReports.ByCategoryKey(evnt.Key, "9");
+        var report = await Client.EventReports.ByCategoryKeyAsync(evnt.Key, "9");
 
         Assert.Equal(17, report.Count());
     }
 
     [Fact]
-    public void ByLabel()
+    public async Task ByLabel()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var report = Client.EventReports.ByLabel(evnt.Key);
+        var report = await Client.EventReports.ByLabelAsync(evnt.Key);
 
         Assert.Single(report["A-1"]);
         Assert.Single(report["A-2"]);
     }
 
     [Fact]
-    public void BySpecificLabel()
+    public async Task BySpecificLabel()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var report = Client.EventReports.ByLabel(evnt.Key, "A-1");
+        var report = await Client.EventReports.ByLabelAsync(evnt.Key, "A-1");
 
         Assert.Single(report);
     }
 
     [Fact]
-    public void ByOrderId()
+    public async Task ByOrderId()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.Book(evnt.Key, new[] {"A-1", "A-2"}, null, "order1");
-        Client.Events.Book(evnt.Key, new[] {"A-3"}, null, "order2");
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.BookAsync(evnt.Key, new[] {"A-1", "A-2"}, null, "order1");
+        await Client.Events.BookAsync(evnt.Key, new[] {"A-3"}, null, "order2");
 
-        var report = Client.EventReports.ByOrderId(evnt.Key);
+        var report = await Client.EventReports.ByOrderIdAsync(evnt.Key);
 
         Assert.Equal(2, report["order1"].Count());
         Assert.Single(report["order2"]);
@@ -266,116 +267,116 @@ public class EventReportsTest : SeatsioClientTest
     }
 
     [Fact]
-    public void BySpecificOrderId()
+    public async Task BySpecificOrderId()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.Book(evnt.Key, new[] {"A-1", "A-2"}, null, "order1");
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.BookAsync(evnt.Key, new[] {"A-1", "A-2"}, null, "order1");
 
-        var report = Client.EventReports.ByOrderId(evnt.Key, "order1");
+        var report = await Client.EventReports.ByOrderIdAsync(evnt.Key, "order1");
 
         Assert.Equal(2, report.Count());
     }
 
     [Fact]
-    public void BySection()
+    public async Task BySection()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var report = Client.EventReports.BySection(evnt.Key);
+        var report = await Client.EventReports.BySectionAsync(evnt.Key);
 
         Assert.Equal(34, report[NoSection].Count());
     }
 
     [Fact]
-    public void BySpecificSection()
+    public async Task BySpecificSection()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
+        var evnt = await Client.Events.CreateAsync(chartKey);
 
-        var report = Client.EventReports.BySection(evnt.Key, NoSection);
+        var report = await Client.EventReports.BySection(evnt.Key, NoSection);
 
         Assert.Equal(34, report.Count());
     }
 
     [Fact]
-    public void ByAvailability()
+    public async Task ByAvailability()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.Book(evnt.Key, new[] {"A-1", "A-2"});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.BookAsync(evnt.Key, new[] {"A-1", "A-2"});
 
-        var report = Client.EventReports.ByAvailability(evnt.Key);
+        var report = await Client.EventReports.ByAvailabilityAsync(evnt.Key);
 
         Assert.Equal(32, report[Available].Count());
         Assert.Equal(2, report[NotAvailable].Count());
     }
 
     [Fact]
-    public void BySpecificAvailability()
+    public async Task BySpecificAvailability()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.Book(evnt.Key, new[] {"A-1", "A-2"});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.BookAsync(evnt.Key, new[] {"A-1", "A-2"});
 
-        var report = Client.EventReports.ByAvailability(evnt.Key, NotAvailable);
+        var report = await Client.EventReports.ByAvailabilityAsync(evnt.Key, NotAvailable);
 
         Assert.Equal(2, report.Count());
     }
-        
+
     [Fact]
-    public void ByAvailabilityReason()
+    public async Task ByAvailabilityReason()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.Book(evnt.Key, new[] {"A-1", "A-2"});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.BookAsync(evnt.Key, new[] {"A-1", "A-2"});
 
-        var report = Client.EventReports.ByAvailabilityReason(evnt.Key);
+        var report = await Client.EventReports.ByAvailabilityReasonAsync(evnt.Key);
 
         Assert.Equal(32, report[Available].Count());
         Assert.Equal(2, report[Booked].Count());
     }
 
     [Fact]
-    public void BySpecificAvailabilityReason()
+    public async Task BySpecificAvailabilityReason()
     {
         var chartKey = CreateTestChart();
-        var evnt = Client.Events.Create(chartKey);
-        Client.Events.Book(evnt.Key, new[] {"A-1", "A-2"});
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        await Client.Events.BookAsync(evnt.Key, new[] {"A-1", "A-2"});
 
-        var report = Client.EventReports.ByAvailabilityReason(evnt.Key, Booked);
+        var report = await Client.EventReports.ByAvailabilityReasonAsync(evnt.Key, Booked);
 
         Assert.Equal(2, report.Count());
     }
 
     [Fact]
-    public void ByChannel()
+    public async Task ByChannel()
     {
         var chartKey = CreateTestChart();
         var channels = new List<Channel>
         {
             new("channelKey1", "channel 1", "#FFFF00", 1, new[] {"A-1", "A-2"})
         };
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithChannels(channels));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithChannels(channels));
 
-        var report = Client.EventReports.ByChannel(evnt.Key);
+        var report = await Client.EventReports.ByChannelAsync(evnt.Key);
 
         Assert.Equal(32, report[NoChannel].Count());
         Assert.Equal(2, report["channelKey1"].Count());
     }
 
     [Fact]
-    public void BySpecificChannel()
+    public async Task BySpecificChannel()
     {
         var chartKey = CreateTestChart();
         var channels = new List<Channel>
         {
             new("channelKey1", "channel 1", "#FFFF00", 1, new[] {"A-1", "A-2"})
         };
-        var evnt = Client.Events.Create(chartKey, new CreateEventParams().WithChannels(channels));
+        var evnt = await Client.Events.CreateAsync(chartKey, new CreateEventParams().WithChannels(channels));
 
-        var report = Client.EventReports.ByChannel(evnt.Key, "channelKey1");
+        var report = await Client.EventReports.ByChannelAsync(evnt.Key, "channelKey1");
 
         Assert.Equal(2, report.Count());
     }

--- a/SeatsioDotNet.Test/Reports/Usage/UsageReportTest.cs
+++ b/SeatsioDotNet.Test/Reports/Usage/UsageReportTest.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading.Tasks;
 using SeatsioDotNet.Reports.Usage;
 using SeatsioDotNet.Reports.Usage.DetailsForEventInMonth;
 using Xunit;
@@ -16,7 +17,7 @@ public class UsageReportTest : SeatsioClientTest
     }
 
     [Fact]
-    public void TestUsageReportForAllMonths()
+    public async Task TestUsageReportForAllMonths()
     {
         if (!DemoCompanySecretKeySet())
         {
@@ -26,7 +27,7 @@ public class UsageReportTest : SeatsioClientTest
 
         var client = CreateSeatsioClient(DemoCompanySecretKey());
 
-        var report = client.UsageReports.SummaryForAllMonths();
+        var report = await client.UsageReports.SummaryForAllMonthsAsync();
 
         Assert.True(report.UsageCutoffDate.Year > 2000);
         Assert.True(report.Usage.Any());
@@ -35,7 +36,7 @@ public class UsageReportTest : SeatsioClientTest
     }
 
     [Fact]
-    public void TestUsageReportForMonth()
+    public async Task TestUsageReportForMonth()
     {
         if (!DemoCompanySecretKeySet())
         {
@@ -45,7 +46,7 @@ public class UsageReportTest : SeatsioClientTest
 
         var client = CreateSeatsioClient(DemoCompanySecretKey());
 
-        var report = client.UsageReports.DetailsForMonth(new UsageMonth(2021, 11));
+        var report = await client.UsageReports.DetailsForMonthAsync(new UsageMonth(2021, 11));
 
         Assert.True(report.Any());
         Assert.True(report.ElementAt(0).UsageByChart.Any());
@@ -53,7 +54,7 @@ public class UsageReportTest : SeatsioClientTest
     }
 
     [Fact]
-    public void TestUsageReportForEventInMonth()
+    public async Task TestUsageReportForEventInMonth()
     {
         if (!DemoCompanySecretKeySet())
         {
@@ -63,7 +64,7 @@ public class UsageReportTest : SeatsioClientTest
 
         var client = CreateSeatsioClient(DemoCompanySecretKey());
 
-        var report = client.UsageReports.DetailsForEventInMonth(580293, new UsageMonth(2021, 11));
+        var report = await client.UsageReports.DetailsForEventInMonthAsync(580293, new UsageMonth(2021, 11));
 
         Assert.True(report.Any());
         Assert.Equal(1, ((UsageForObjectV1) report.ElementAt(0)).NumFirstSelections);

--- a/SeatsioDotNet.Test/Seasons/AddEventsToPartialSeasonTest.cs
+++ b/SeatsioDotNet.Test/Seasons/AddEventsToPartialSeasonTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Seasons;
@@ -6,13 +7,13 @@ namespace SeatsioDotNet.Test.Seasons;
 public class AddEventsToPartialSeasonTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
         var chartKey = CreateTestChart();
-        var topLevelSeason = Client.Seasons.Create(chartKey, eventKeys: new[] {"event1", "event2"});
-        var partialSeason = Client.Seasons.CreatePartialSeason(topLevelSeason.Key, partialSeasonKey: "aPartialSeason");
+        var topLevelSeason = await Client.Seasons.CreateAsync(chartKey, eventKeys: new[] {"event1", "event2"});
+        var partialSeason = await Client.Seasons.CreatePartialSeasonAsync(topLevelSeason.Key, partialSeasonKey: "aPartialSeason");
 
-        var updatedPartialSeason = Client.Seasons.AddEventsToPartialSeason(topLevelSeason.Key, partialSeason.Key, new[] {"event1", "event2"});
+        var updatedPartialSeason = await Client.Seasons.AddEventsToPartialSeasonAsync(topLevelSeason.Key, partialSeason.Key, new[] {"event1", "event2"});
 
         Assert.Equal(new[] {"event1", "event2"}, updatedPartialSeason.Events.Select(e => e.Key));
         Assert.Equal(new[] {updatedPartialSeason.Key}, updatedPartialSeason.Events[0].PartialSeasonKeysForEvent);

--- a/SeatsioDotNet.Test/Seasons/CreateEventsInSeasonTest.cs
+++ b/SeatsioDotNet.Test/Seasons/CreateEventsInSeasonTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Seasons;
@@ -6,12 +7,12 @@ namespace SeatsioDotNet.Test.Seasons;
 public class CreateEventsInSeasonTest : SeatsioClientTest
 {
     [Fact]
-    public void EventsKeysCanBePassedIn()
+    public async Task EventsKeysCanBePassedIn()
     {
         var chartKey = CreateTestChart();
-        var season = Client.Seasons.Create(chartKey);
+        var season = await Client.Seasons.CreateAsync(chartKey);
 
-        var events = Client.Seasons.CreateEvents(season.Key, eventKeys: new[] {"event1", "event2"});
+        var events = await Client.Seasons.CreateEventsAsync(season.Key, eventKeys: new[] {"event1", "event2"});
 
         Assert.Equal(new[] {"event2", "event1"}, events.Select(e => e.Key));
         Assert.True(events[0].IsEventInSeason);
@@ -19,12 +20,12 @@ public class CreateEventsInSeasonTest : SeatsioClientTest
     }
 
     [Fact]
-    public void NumberOfEventsCanBePassedIn()
+    public async Task NumberOfEventsCanBePassedIn()
     {
         var chartKey = CreateTestChart();
-        var season = Client.Seasons.Create(chartKey);
+        var season = await Client.Seasons.CreateAsync(chartKey);
 
-        var events = Client.Seasons.CreateEvents(season.Key, numberOfEvents: 2);
+        var events = await Client.Seasons.CreateEventsAsync(season.Key, numberOfEvents: 2);
 
         Assert.Equal(2, events.Length);
     }

--- a/SeatsioDotNet.Test/Seasons/CreatePartialSeasonTest.cs
+++ b/SeatsioDotNet.Test/Seasons/CreatePartialSeasonTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Seasons;
@@ -6,12 +7,12 @@ namespace SeatsioDotNet.Test.Seasons;
 public class CreatePartialSeasonTest : SeatsioClientTest
 {
     [Fact]
-    public void KeyCanBePassedIn()
+    public async Task KeyCanBePassedIn()
     {
         var chartKey = CreateTestChart();
-        var topLevelSeason = Client.Seasons.Create(chartKey);
+        var topLevelSeason = await Client.Seasons.CreateAsync(chartKey);
 
-        var partialSeason = Client.Seasons.CreatePartialSeason(topLevelSeason.Key, partialSeasonKey: "aPartialSeason");
+        var partialSeason = await Client.Seasons.CreatePartialSeasonAsync(topLevelSeason.Key, partialSeasonKey: "aPartialSeason");
 
         Assert.Equal("aPartialSeason", partialSeason.Key);
         Assert.True(partialSeason.IsPartialSeason);
@@ -19,12 +20,12 @@ public class CreatePartialSeasonTest : SeatsioClientTest
     }
 
     [Fact]
-    public void EventKeysCanBePassedIn()
+    public async Task EventKeysCanBePassedIn()
     {
         var chartKey = CreateTestChart();
-        var topLevelSeason = Client.Seasons.Create(chartKey, eventKeys: new[] {"event1", "event2"});
+        var topLevelSeason = await Client.Seasons.CreateAsync(chartKey, eventKeys: new[] {"event1", "event2"});
 
-        var partialSeason = Client.Seasons.CreatePartialSeason(topLevelSeason.Key, eventKeys: new[] {"event1", "event2"});
+        var partialSeason = await Client.Seasons.CreatePartialSeasonAsync(topLevelSeason.Key, eventKeys: new[] {"event1", "event2"});
 
         Assert.Equal(new[] {"event1", "event2"}, partialSeason.Events.Select(e => e.Key));
         Assert.Equal(new[] {partialSeason.Key}, partialSeason.Events[0].PartialSeasonKeysForEvent);

--- a/SeatsioDotNet.Test/Seasons/CreateSeasonTest.cs
+++ b/SeatsioDotNet.Test/Seasons/CreateSeasonTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using SeatsioDotNet.Events;
 using Xunit;
 
@@ -9,11 +10,11 @@ namespace SeatsioDotNet.Test.Seasons;
 public class CreateSeasonTest : SeatsioClientTest
 {
     [Fact]
-    public void ChartKeyIsMandatory()
+    public async Task ChartKeyIsMandatory()
     {
         var chartKey = CreateTestChart();
 
-        var season = Client.Seasons.Create(chartKey);
+        var season = await Client.Seasons.CreateAsync(chartKey);
 
         Assert.NotNull(season.Key);
         Assert.NotEqual(0, season.Id);
@@ -30,47 +31,47 @@ public class CreateSeasonTest : SeatsioClientTest
     }
 
     [Fact]
-    public void KeyCanBePassedIn()
+    public async Task KeyCanBePassedIn()
     {
         var chartKey = CreateTestChart();
 
-        var season = Client.Seasons.Create(chartKey, key: "aSeason");
+        var season = await Client.Seasons.CreateAsync(chartKey, key: "aSeason");
 
         Assert.Equal("aSeason", season.Key);
     }    
         
     [Fact]
-    public void NumberOfEventsCanBePassedIn()
+    public async Task NumberOfEventsCanBePassedIn()
     {
         var chartKey = CreateTestChart();
 
-        var season = Client.Seasons.Create(chartKey, numberOfEvents: 2);
+        var season = await Client.Seasons.CreateAsync(chartKey, numberOfEvents: 2);
 
         Assert.Equal(2, season.Events.Count);
     }   
         
     [Fact]
-    public void EventKeysCanBePassedIn()
+    public async Task EventKeysCanBePassedIn()
     {
         var chartKey = CreateTestChart();
 
-        var season = Client.Seasons.Create(chartKey, eventKeys: new[] {"event1", "event2"});
+        var season = await Client.Seasons.CreateAsync(chartKey, eventKeys: new[] {"event1", "event2"});
 
         Assert.Equal(new[] {"event1", "event2"}, season.Events.Select(e => e.Key));
     }   
         
     [Fact]
-    public void TableBookingConfigCanBePassedIn()
+    public async Task TableBookingConfigCanBePassedIn()
     {
         var chartKey = CreateTestChart();
 
-        var season = Client.Seasons.Create(chartKey, tableBookingConfig: TableBookingConfig.AllBySeat());
+        var season = await Client.Seasons.CreateAsync(chartKey, tableBookingConfig: TableBookingConfig.AllBySeat());
 
         Assert.Equal(TableBookingConfig.AllBySeat().Mode, season.TableBookingConfig.Mode);
     }
         
     [Fact]
-    public void ChannelsCanBePassedIn()
+    public async Task ChannelsCanBePassedIn()
     {
         var chartKey = CreateTestChart();
         var channels = new List<Channel>
@@ -79,18 +80,18 @@ public class CreateSeasonTest : SeatsioClientTest
             new("channelKey2", "channel 2", "#00FFFF", 2, new String[] {})
         };
             
-        var season = Client.Seasons.Create(chartKey, channels: channels);
+        var season = await Client.Seasons.CreateAsync(chartKey, channels: channels);
 
         Assert.Equivalent(channels, season.Channels);
     }
         
     [Fact]
-    public void ForSaleConfigCanBePassedIn()
+    public async Task ForSaleConfigCanBePassedIn()
     {
         var chartKey = CreateTestChart();
         var forSaleConfig = new ForSaleConfig().WithForSale(false).WithObjects(new []{"A-1"}).WithAreaPlaces(new(){{"GA1", 5}}).WithCategories(new []{"Cat1"});
             
-        var season = Client.Seasons.Create(chartKey, forSaleConfig: forSaleConfig);
+        var season = await Client.Seasons.CreateAsync(chartKey, forSaleConfig: forSaleConfig);
 
         Assert.Equivalent(forSaleConfig, season.ForSaleConfig);
     }

--- a/SeatsioDotNet.Test/Seasons/RemoveEventFromPartialSeasonTest.cs
+++ b/SeatsioDotNet.Test/Seasons/RemoveEventFromPartialSeasonTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Seasons;
@@ -6,13 +7,13 @@ namespace SeatsioDotNet.Test.Seasons;
 public class RemoveEventFromPartialSeasonTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
         var chartKey = CreateTestChart();
-        var topLevelSeason = Client.Seasons.Create(chartKey, eventKeys: new[] {"event1", "event2"});
-        var partialSeason = Client.Seasons.CreatePartialSeason(topLevelSeason.Key, eventKeys: new[] {"event1", "event2"});
+        var topLevelSeason = await Client.Seasons.CreateAsync(chartKey, eventKeys: new[] {"event1", "event2"});
+        var partialSeason = await Client.Seasons.CreatePartialSeasonAsync(topLevelSeason.Key, eventKeys: new[] {"event1", "event2"});
 
-        var updatedPartialSeason = Client.Seasons.RemoveEventFromPartialSeason(topLevelSeason.Key, partialSeason.Key, "event2");
+        var updatedPartialSeason = await Client.Seasons.RemoveEventFromPartialSeasonAsync(topLevelSeason.Key, partialSeason.Key, "event2");
 
         Assert.Equal(new[] {"event1"}, updatedPartialSeason.Events.Select(e => e.Key));
     }

--- a/SeatsioDotNet.Test/Seasons/RetrieveSeasonTest.cs
+++ b/SeatsioDotNet.Test/Seasons/RetrieveSeasonTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Seasons;
@@ -6,15 +7,15 @@ namespace SeatsioDotNet.Test.Seasons;
 public class RetrieveSeasonTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
         var chartKey = CreateTestChart();
 
-        var season = Client.Seasons.Create(chartKey);
-        var partialSeason1 = Client.Seasons.CreatePartialSeason(season.Key);
-        var partialSeason2 = Client.Seasons.CreatePartialSeason(season.Key);
+        var season = await Client.Seasons.CreateAsync(chartKey);
+        var partialSeason1 = await Client.Seasons.CreatePartialSeasonAsync(season.Key);
+        var partialSeason2 = await Client.Seasons.CreatePartialSeasonAsync(season.Key);
 
-        var retrievedSeason = Client.Seasons.Retrieve(season.Key);
+        var retrievedSeason = await  Client.Seasons.RetrieveAsync(season.Key);
 
         Assert.NotNull(retrievedSeason.Key);
         Assert.NotEqual(0, retrievedSeason.Id);

--- a/SeatsioDotNet.Test/SeatsioClientTest.cs
+++ b/SeatsioDotNet.Test/SeatsioClientTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using RestSharp;
 using RestSharp.Authenticators;
 using SeatsioDotNet.Charts;
@@ -91,13 +92,13 @@ public class SeatsioClientTest
         return new SeatsioClient(secretKey, workspaceKey, BaseUrl);
     }
 
-    protected void WaitForStatusChanges(SeatsioClient client, Event evnt, int numStatusChanges)
+    protected async Task WaitForStatusChanges(SeatsioClient client, Event evnt, int numStatusChanges)
     {
         var start = DateTimeOffset.Now;
         while (true)
         {
-            var statusChanges = client.Events.StatusChanges(evnt.Key).All();
-            if (statusChanges.ToList().Count != numStatusChanges)
+            var statusChanges = await client.Events.StatusChanges(evnt.Key).AllAsync().ToListAsync();
+            if (statusChanges.Count != numStatusChanges)
             {
                 var duration = DateTimeOffset.Now.ToUnixTimeSeconds() - start.ToUnixTimeSeconds();
                 if (duration > 10)

--- a/SeatsioDotNet.Test/SeatsioDotNet.Test.csproj
+++ b/SeatsioDotNet.Test/SeatsioDotNet.Test.csproj
@@ -4,9 +4,13 @@
     <TargetFrameworks>net6.0</TargetFrameworks>
 	</PropertyGroup>
 	<ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
 		<ProjectReference Include="..\SeatsioDotNet\SeatsioDotNet.csproj" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageReference Include="xunit" Version="2.7.0" />
     <PackageReference Include="RestSharp" Version="110.2.0" />

--- a/SeatsioDotNet.Test/WorkspaceKeyAuthenticationTest.cs
+++ b/SeatsioDotNet.Test/WorkspaceKeyAuthenticationTest.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SeatsioDotNet.Test;
@@ -5,12 +6,12 @@ namespace SeatsioDotNet.Test;
 public class WorkspaceKeyAuthenticationTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var workspace = Client.Workspaces.Create("some workspace");
+        var workspace = await Client.Workspaces.CreateAsync("some workspace");
 
         var workspaceClient = CreateSeatsioClient(User.SecretKey, workspace.Key);
-        var holdToken = workspaceClient.HoldTokens.Create();
+        var holdToken = await workspaceClient.HoldTokens.CreateAsync();
 
         Assert.Equal(workspace.Key, holdToken.workspaceKey);
     }

--- a/SeatsioDotNet.Test/Workspaces/ActivateWorkspaceTest.cs
+++ b/SeatsioDotNet.Test/Workspaces/ActivateWorkspaceTest.cs
@@ -1,18 +1,19 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace SeatsioDotNet.Test.Workspaces;
 
 public class ActivateWorkspaceTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var workspace = Client.Workspaces.Create("a ws");
-        Client.Workspaces.Deactivate(workspace.Key);
+        var workspace = await Client.Workspaces.CreateAsync("a ws");
+        await Client.Workspaces.DeactivateAsync(workspace.Key);
 
-        Client.Workspaces.Activate(workspace.Key);
+        await Client.Workspaces.ActivateAsync(workspace.Key);
 
-        var retrievedWorkspace = Client.Workspaces.Retrieve(workspace.Key);
+        var retrievedWorkspace = await Client.Workspaces.RetrieveAsync(workspace.Key);
         Assert.True(retrievedWorkspace.IsActive);
     }
 }

--- a/SeatsioDotNet.Test/Workspaces/CreateWorkspaceTest.cs
+++ b/SeatsioDotNet.Test/Workspaces/CreateWorkspaceTest.cs
@@ -1,13 +1,14 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace SeatsioDotNet.Test.Workspaces;
 
 public class CreateWorkspaceTest : SeatsioClientTest
 {
     [Fact]
-    public void CreateWorkspace()
+    public async Task CreateWorkspace()
     {
-        var workspace = Client.Workspaces.Create("my workspace");
+        var workspace = await Client.Workspaces.CreateAsync("my workspace");
 
         Assert.Equal("my workspace", workspace.Name);
         Assert.NotNull(workspace.Key);
@@ -17,9 +18,9 @@ public class CreateWorkspaceTest : SeatsioClientTest
     } 
         
     [Fact]
-    public void CreateTestWorkspace()
+    public async Task CreateTestWorkspace()
     {
-        var workspace = Client.Workspaces.Create("my workspace", true);
+        var workspace = await Client.Workspaces.CreateAsync("my workspace", true);
 
         Assert.Equal("my workspace", workspace.Name);
         Assert.NotNull(workspace.Key);

--- a/SeatsioDotNet.Test/Workspaces/DeactivateWorkspaceTest.cs
+++ b/SeatsioDotNet.Test/Workspaces/DeactivateWorkspaceTest.cs
@@ -1,17 +1,18 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace SeatsioDotNet.Test.Workspaces;
 
 public class DeactivateWorkspaceTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var workspace = Client.Workspaces.Create("a ws");
+        var workspace = await Client.Workspaces.CreateAsync("a ws");
             
-        Client.Workspaces.Deactivate(workspace.Key);
+        await Client.Workspaces.DeactivateAsync(workspace.Key);
 
-        var retrievedWorkspace = Client.Workspaces.Retrieve(workspace.Key);
+        var retrievedWorkspace = await Client.Workspaces.RetrieveAsync(workspace.Key);
         Assert.False(retrievedWorkspace.IsActive);
     }
 }

--- a/SeatsioDotNet.Test/Workspaces/ListActiveWorkspacesTest.cs
+++ b/SeatsioDotNet.Test/Workspaces/ListActiveWorkspacesTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Workspaces;
@@ -6,14 +7,14 @@ namespace SeatsioDotNet.Test.Workspaces;
 public class ListActiveWorkspacesTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        Client.Workspaces.Create("ws1");
+        await Client.Workspaces.CreateAsync("ws1");
 
-        var ws2 = Client.Workspaces.Create("ws2");
-        Client.Workspaces.Deactivate(ws2.Key);
+        var ws2 = await Client.Workspaces.CreateAsync("ws2");
+        await Client.Workspaces.DeactivateAsync(ws2.Key);
 
-        Client.Workspaces.Create("ws3");
+        await Client.Workspaces.CreateAsync("ws3");
 
         var workspaces = Client.Workspaces.Active.All();
 
@@ -21,13 +22,13 @@ public class ListActiveWorkspacesTest : SeatsioClientTest
     }
 
     [Fact]
-    public void Filter()
+    public async Task Filter()
     {
-        Client.Workspaces.Create("someWorkspace");
-        Client.Workspaces.Create("anotherWorkspace");
-        Client.Workspaces.Create("anotherAnotherWorkspace");
-        var ws = Client.Workspaces.Create("anoherAnotherAnotherWorkspace");
-        Client.Workspaces.Deactivate(ws.Key);
+        await Client.Workspaces.CreateAsync("someWorkspace");
+        await Client.Workspaces.CreateAsync("anotherWorkspace");
+        await Client.Workspaces.CreateAsync("anotherAnotherWorkspace");
+        var ws = await Client.Workspaces.CreateAsync("anoherAnotherAnotherWorkspace");
+        await Client.Workspaces.DeactivateAsync(ws.Key);
 
         var workspaces = Client.Workspaces.Active.All("another");
 

--- a/SeatsioDotNet.Test/Workspaces/ListActiveWorkspacesTest.cs
+++ b/SeatsioDotNet.Test/Workspaces/ListActiveWorkspacesTest.cs
@@ -16,7 +16,7 @@ public class ListActiveWorkspacesTest : SeatsioClientTest
 
         await Client.Workspaces.CreateAsync("ws3");
 
-        var workspaces = Client.Workspaces.Active.All();
+        var workspaces = Client.Workspaces.Active.AllAsync();
 
         Assert.Equal(new[] {"ws3", "ws1", "Default workspace"}, workspaces.Select(e => e.Name));
     }
@@ -30,7 +30,7 @@ public class ListActiveWorkspacesTest : SeatsioClientTest
         var ws = await Client.Workspaces.CreateAsync("anoherAnotherAnotherWorkspace");
         await Client.Workspaces.DeactivateAsync(ws.Key);
 
-        var workspaces = Client.Workspaces.Active.All("another");
+        var workspaces = Client.Workspaces.Active.AllAsync("another");
 
         Assert.Equal(new[] {"anotherAnotherWorkspace", "anotherWorkspace"}, workspaces.Select(e => e.Name));
     }

--- a/SeatsioDotNet.Test/Workspaces/ListInactiveWorkspacesTest.cs
+++ b/SeatsioDotNet.Test/Workspaces/ListInactiveWorkspacesTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Workspaces;
@@ -6,15 +7,15 @@ namespace SeatsioDotNet.Test.Workspaces;
 public class ListInactiveWorkspacesTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var ws1 = Client.Workspaces.Create("ws1");
-        Client.Workspaces.Deactivate(ws1.Key);
+        var ws1 = await Client.Workspaces.CreateAsync("ws1");
+        await Client.Workspaces.DeactivateAsync(ws1.Key);
 
-        Client.Workspaces.Create("ws2");
+        await Client.Workspaces.CreateAsync("ws2");
 
-        var ws3 = Client.Workspaces.Create("ws3");
-        Client.Workspaces.Deactivate(ws3.Key);
+        var ws3 = await Client.Workspaces.CreateAsync("ws3");
+        await Client.Workspaces.DeactivateAsync(ws3.Key);
 
         var workspaces = Client.Workspaces.Inactive.All();
 
@@ -22,17 +23,17 @@ public class ListInactiveWorkspacesTest : SeatsioClientTest
     }
 
     [Fact]
-    public void Filter()
+    public async Task Filter()
     {
-        Client.Workspaces.Create("someWorkspace");
+        await Client.Workspaces.CreateAsync("someWorkspace");
             
-        var ws1 = Client.Workspaces.Create("anotherWorkspace");
-        Client.Workspaces.Deactivate(ws1.Key);
+        var ws1 = await Client.Workspaces.CreateAsync("anotherWorkspace");
+        await Client.Workspaces.DeactivateAsync(ws1.Key);
             
-        var ws2 = Client.Workspaces.Create("anotherAnotherWorkspace");
-        Client.Workspaces.Deactivate(ws2.Key);
+        var ws2 = await Client.Workspaces.CreateAsync("anotherAnotherWorkspace");
+        await Client.Workspaces.DeactivateAsync(ws2.Key);
             
-        var ws = Client.Workspaces.Create("anoherAnotherAnotherWorkspace");
+        var ws = await Client.Workspaces.CreateAsync("anoherAnotherAnotherWorkspace");
 
         var workspaces = Client.Workspaces.Inactive.All("another");
 

--- a/SeatsioDotNet.Test/Workspaces/ListInactiveWorkspacesTest.cs
+++ b/SeatsioDotNet.Test/Workspaces/ListInactiveWorkspacesTest.cs
@@ -17,7 +17,7 @@ public class ListInactiveWorkspacesTest : SeatsioClientTest
         var ws3 = await Client.Workspaces.CreateAsync("ws3");
         await Client.Workspaces.DeactivateAsync(ws3.Key);
 
-        var workspaces = Client.Workspaces.Inactive.All();
+        var workspaces = Client.Workspaces.Inactive.AllAsync();
 
         Assert.Equal(new[] {"ws3", "ws1"}, workspaces.Select(e => e.Name));
     }
@@ -35,7 +35,7 @@ public class ListInactiveWorkspacesTest : SeatsioClientTest
             
         var ws = await Client.Workspaces.CreateAsync("anoherAnotherAnotherWorkspace");
 
-        var workspaces = Client.Workspaces.Inactive.All("another");
+        var workspaces = Client.Workspaces.Inactive.AllAsync("another");
 
         Assert.Equal(new[] {"anotherAnotherWorkspace", "anotherWorkspace"}, workspaces.Select(e => e.Name));
     }

--- a/SeatsioDotNet.Test/Workspaces/ListWorkspacesTest.cs
+++ b/SeatsioDotNet.Test/Workspaces/ListWorkspacesTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SeatsioDotNet.Test.Workspaces;
@@ -6,29 +7,29 @@ namespace SeatsioDotNet.Test.Workspaces;
 public class ListWorkspacesTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        Client.Workspaces.Create("ws1");
+        await Client.Workspaces.CreateAsync("ws1");
             
-        var ws2 = Client.Workspaces.Create("ws2");
-        Client.Workspaces.Deactivate(ws2.Key);
+        var ws2 = await Client.Workspaces.CreateAsync("ws2");
+        await Client.Workspaces.DeactivateAsync(ws2.Key);
             
-        Client.Workspaces.Create("ws3");
+        await Client.Workspaces.CreateAsync("ws3");
 
-        var workspaces = Client.Workspaces.ListAll();
+        var workspaces = await Client.Workspaces.ListAllAsync().ToListAsync();
 
         Assert.Equal(new[] {"ws3", "ws2", "ws1", "Default workspace"}, workspaces.Select(e => e.Name));
     }  
         
     [Fact]
-    public void Filter()
+    public async Task Filter()
     {
-        Client.Workspaces.Create("someWorkspace");
-        Client.Workspaces.Create("anotherWorkspace");
-        var ws = Client.Workspaces.Create("anotherAnotherWorkspace");
-        Client.Workspaces.Deactivate(ws.Key);
+        await Client.Workspaces.CreateAsync("someWorkspace");
+        await Client.Workspaces.CreateAsync("anotherWorkspace");
+        var ws = await Client.Workspaces.CreateAsync("anotherAnotherWorkspace");
+        await Client.Workspaces.DeactivateAsync(ws.Key);
 
-        var workspaces = Client.Workspaces.ListAll("another");
+        var workspaces = await Client.Workspaces.ListAllAsync("another").ToListAsync();
 
         Assert.Equal(new[] {"anotherAnotherWorkspace", "anotherWorkspace"}, workspaces.Select(e => e.Name));
     }

--- a/SeatsioDotNet.Test/Workspaces/RegenerateWorkspaceSecretKeyTest.cs
+++ b/SeatsioDotNet.Test/Workspaces/RegenerateWorkspaceSecretKeyTest.cs
@@ -1,19 +1,20 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace SeatsioDotNet.Test.Workspaces;
 
 public class RegenerateWorkspaceSecretKeyTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var workspace = Client.Workspaces.Create("a ws");
+        var workspace = await Client.Workspaces.CreateAsync("a ws");
             
-        var newSecretKey = Client.Workspaces.RegenerateSecretKey(workspace.Key);
+        var newSecretKey = await Client.Workspaces.RegenerateSecretKeyAsync(workspace.Key);
 
         Assert.NotNull(newSecretKey);
         Assert.NotEqual(newSecretKey, workspace.SecretKey);
-        var retrievedWorkspace = Client.Workspaces.Retrieve(workspace.Key);
+        var retrievedWorkspace = await Client.Workspaces.RetrieveAsync(workspace.Key);
         Assert.Equal(newSecretKey, retrievedWorkspace.SecretKey);
     }
 }

--- a/SeatsioDotNet.Test/Workspaces/RetrieveWorkspaceTest.cs
+++ b/SeatsioDotNet.Test/Workspaces/RetrieveWorkspaceTest.cs
@@ -1,15 +1,16 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace SeatsioDotNet.Test.Workspaces;
 
 public class RetrieveWorkspaceTest : SeatsioClientTest
 {
     [Fact]
-    public void RetrieveWorkspace()
+    public async Task RetrieveWorkspace()
     {
-        var workspace = Client.Workspaces.Create("my workspace");
+        var workspace = await Client.Workspaces.CreateAsync("my workspace");
 
-        var retrievedWorkspace = Client.Workspaces.Retrieve(workspace.Key);
+        var retrievedWorkspace = await Client.Workspaces.RetrieveAsync(workspace.Key);
 
         Assert.Equal("my workspace", retrievedWorkspace.Name);
         Assert.NotNull(retrievedWorkspace.Key);

--- a/SeatsioDotNet.Test/Workspaces/SetDefaultWorkspaceTest.cs
+++ b/SeatsioDotNet.Test/Workspaces/SetDefaultWorkspaceTest.cs
@@ -1,17 +1,18 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace SeatsioDotNet.Test.Workspaces;
 
 public class SetDefaultWorkspaceTest : SeatsioClientTest
 {
     [Fact]
-    public void Test()
+    public async Task Test()
     {
-        var workspace = Client.Workspaces.Create("a ws");
+        var workspace = await Client.Workspaces.CreateAsync("a ws");
             
-        Client.Workspaces.SetDefault(workspace.Key);
+        await Client.Workspaces.SetDefaultAsync(workspace.Key);
 
-        var retrievedWorkspace = Client.Workspaces.Retrieve(workspace.Key);
+        var retrievedWorkspace = await Client.Workspaces.RetrieveAsync(workspace.Key);
         Assert.True(retrievedWorkspace.IsDefault);
     }
 }

--- a/SeatsioDotNet.Test/Workspaces/UpdateWorkspaceTest.cs
+++ b/SeatsioDotNet.Test/Workspaces/UpdateWorkspaceTest.cs
@@ -1,17 +1,18 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace SeatsioDotNet.Test.Workspaces;
 
 public class UpdateWorkspaceTest : SeatsioClientTest
 {
     [Fact]
-    public void UpdateWorkspace()
+    public async Task UpdateWorkspace()
     {
-        var workspace = Client.Workspaces.Create("my workspace");
+        var workspace = await Client.Workspaces.CreateAsync("my workspace");
 
-        Client.Workspaces.Update(workspace.Key, "my ws");
+        await Client.Workspaces.UpdateAsync(workspace.Key, "my ws");
 
-        var retrievedWorkspace = Client.Workspaces.Retrieve(workspace.Key);
+        var retrievedWorkspace = await Client.Workspaces.RetrieveAsync(workspace.Key);
         Assert.Equal("my ws", retrievedWorkspace.Name);
         Assert.NotNull(retrievedWorkspace.Key);
         Assert.NotNull(retrievedWorkspace.SecretKey);

--- a/SeatsioDotNet/Charts/Charts.cs
+++ b/SeatsioDotNet/Charts/Charts.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 using RestSharp;
 using SeatsioDotNet.Util;
 using static SeatsioDotNet.Util.RestUtil;
@@ -19,7 +20,7 @@ public class Charts
         Archive = new Lister<Chart>(new PageFetcher<Chart>(_restClient, "/charts/archive"));
     }
 
-    public Chart Create(string name = null, string venueType = null, IEnumerable<Category> categories = null)
+    public async Task<Chart> CreateAsync(string name = null, string venueType = null, IEnumerable<Category> categories = null)
     {
         var requestBody = new Dictionary<string, object>();
 
@@ -40,10 +41,10 @@ public class Charts
 
         var restRequest = new RestRequest("/charts", Method.Post)
             .AddJsonBody(requestBody);
-        return AssertOk(_restClient.Execute<Chart>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Chart>(restRequest));
     }
 
-    public void Update(string chartKey, string name = null, IEnumerable<Category> categories = null)
+    public async Task UpdateAsync(string chartKey, string name = null, IEnumerable<Category> categories = null)
     {
         var requestBody = new Dictionary<string, object>();
 
@@ -60,29 +61,29 @@ public class Charts
         var restRequest = new RestRequest("/charts/{key}", Method.Post)
             .AddUrlSegment("key", chartKey)
             .AddJsonBody(requestBody);
-        AssertOk(_restClient.Execute<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
     }
         
-    public void AddCategory(string chartKey, Category category)
+    public async Task AddCategoryAsync(string chartKey, Category category)
     {
         var restRequest = new RestRequest("/charts/{chartKey}/categories", Method.Post)
             .AddUrlSegment("chartKey", chartKey)
             .AddJsonBody(category.AsDictionary());
-        AssertOk(_restClient.Execute<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
     }
 
-    public void RemoveCategory(string chartKey, object categoryKey)
+    public async Task RemoveCategoryAsync(string chartKey, object categoryKey)
     {
         var restRequest = new RestRequest("/charts/{chartKey}/categories/{categoryKey}", Method.Delete)
             .AddUrlSegment("chartKey", chartKey)
             .AddUrlSegment("categoryKey", categoryKey.ToString());
-        AssertOk(_restClient.Execute<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
     }
 
-    public IEnumerable<Category> ListCategories(string chartKey)
+    public async Task<IEnumerable<Category>> ListCategoriesAsync(string chartKey)
     {
         var restRequest = new RestRequest($"/charts/{chartKey}/categories", Method.Get);
-        return _restClient.Execute<CategoryList>(restRequest).Data.List;
+        return (await _restClient.ExecuteAsync<CategoryList>(restRequest)).Data.List;
     }
 
     private class CategoryList
@@ -91,54 +92,54 @@ public class Charts
         public IEnumerable<Category> List { get; set; }
     }
 
-    public Chart Copy(string chartKey)
+    public async Task<Chart> CopyAsync(string chartKey)
     {
         var restRequest = new RestRequest("/charts/{key}/version/published/actions/copy", Method.Post)
             .AddUrlSegment("key", chartKey);
-        return AssertOk(_restClient.Execute<Chart>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Chart>(restRequest));
     }
 
-    public Chart CopyToWorkspace(string chartKey, string toWorkspaceKey)
+    public async Task<Chart> CopyToWorkspaceAsync(string chartKey, string toWorkspaceKey)
     {
         var restRequest = new RestRequest("/charts/{key}/version/published/actions/copy-to-workspace/{toWorkspaceKey}", Method.Post)
             .AddUrlSegment("key", chartKey)
             .AddUrlSegment("toWorkspaceKey", toWorkspaceKey);
-        return AssertOk(_restClient.Execute<Chart>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Chart>(restRequest));
     }
         
-    public Chart CopyToWorkspace(string chartKey, string fromWorkspaceKey, string toWorkspaceKey)
+    public async Task<Chart> CopyToWorkspaceAsync(string chartKey, string fromWorkspaceKey, string toWorkspaceKey)
     {
         var restRequest = new RestRequest($"/charts/{chartKey}/version/published/actions/copy/from/{fromWorkspaceKey}/to/{toWorkspaceKey}", Method.Post)
             .AddUrlSegment("chartKey", chartKey)
             .AddUrlSegment("fromWorkspaceKey", fromWorkspaceKey)
             .AddUrlSegment("toWorkspaceKey", toWorkspaceKey);
-        return AssertOk(_restClient.Execute<Chart>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Chart>(restRequest));
     }
 
-    public Chart CopyDraftVersion(string chartKey)
+    public async Task<Chart> CopyDraftVersionAsync(string chartKey)
     {
         var restRequest = new RestRequest("/charts/{key}/version/draft/actions/copy", Method.Post)
             .AddUrlSegment("key", chartKey);
-        return AssertOk(_restClient.Execute<Chart>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Chart>(restRequest));
     }
 
-    public void AddTag(string chartKey, string tag)
+    public async Task AddTagAsync(string chartKey, string tag)
     {
         var restRequest = new RestRequest("/charts/{key}/tags/{tag}", Method.Post)
             .AddUrlSegment("key", chartKey)
             .AddUrlSegment("tag", tag);
-        AssertOk(_restClient.Execute<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
     }
 
-    public void RemoveTag(string chartKey, string tag)
+    public async Task RemoveTagAsync(string chartKey, string tag)
     {
         var restRequest = new RestRequest("/charts/{key}/tags/{tag}", Method.Delete)
             .AddUrlSegment("key", chartKey)
             .AddUrlSegment("tag", tag);
-        AssertOk(_restClient.Execute<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
     }
         
-    public Chart Retrieve(string chartKey, bool? expandEvents = null)
+    public async Task<Chart> RetrieveAsync(string chartKey, bool? expandEvents = null)
     {
         var restRequest = new RestRequest("/charts/{key}", Method.Get)
             .AddUrlSegment("key", chartKey);
@@ -148,13 +149,13 @@ public class Charts
             restRequest.AddQueryParameter("expand", "events");
         }
 
-        return AssertOk(_restClient.Execute<Chart>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Chart>(restRequest));
     }
 
-    public IEnumerable<string> ListAllTags()
+    public async Task<IEnumerable<string>> ListAllTagsAsync()
     {
         var restRequest = new RestRequest("/charts/tags", Method.Get);
-        return AssertOk(_restClient.Execute<Tags>(restRequest)).List;
+        return AssertOk(await _restClient.ExecuteAsync<Tags>(restRequest)).List;
     }
 
     private class Tags
@@ -163,98 +164,98 @@ public class Charts
         public IEnumerable<string> List { get; set; }
     }
 
-    public void MoveToArchive(string chartKey)
+    public async Task MoveToArchiveAsync(string chartKey)
     {
         var restRequest = new RestRequest("/charts/{key}/actions/move-to-archive", Method.Post)
             .AddUrlSegment("key", chartKey);
-        AssertOk(_restClient.Execute<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
     }
 
-    public void MoveOutOfArchive(string chartKey)
+    public async Task MoveOutOfArchiveAsync(string chartKey)
     {
         var restRequest = new RestRequest("/charts/{key}/actions/move-out-of-archive", Method.Post)
             .AddUrlSegment("key", chartKey);
-        AssertOk(_restClient.Execute<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
     }
 
-    public Drawing RetrievePublishedVersion(string chartKey)
+    public async Task<Drawing> RetrievePublishedVersionAsync(string chartKey)
     {
         var restRequest = new RestRequest("/charts/{key}/version/published", Method.Get)
             .AddUrlSegment("key", chartKey);
-        return AssertOk(_restClient.Execute<Drawing>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Drawing>(restRequest));
     }
 
-    public byte[] RetrievePublishedVersionThumbnail(string chartKey)
+    public async Task<byte[]> RetrievePublishedVersionThumbnailAsync(string chartKey)
     {
         var restRequest = new RestRequest("/charts/{key}/version/published/thumbnail", Method.Get)
             .AddUrlSegment("key", chartKey);
-        var restResponse = _restClient.Execute<object>(restRequest);
+        var restResponse = await _restClient.ExecuteAsync<object>(restRequest);
         AssertOk(restResponse);
         return restResponse.RawBytes;
     }
 
-    public Drawing RetrieveDraftVersion(string chartKey)
+    public async Task<Drawing> RetrieveDraftVersionAsync(string chartKey)
     {
         var restRequest = new RestRequest("/charts/{key}/version/draft", Method.Get)
             .AddUrlSegment("key", chartKey);
-        return AssertOk(_restClient.Execute<Drawing>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Drawing>(restRequest));
     }
 
-    public byte[] RetrieveDraftVersionThumbnail(string chartKey)
+    public async Task<byte[]> RetrieveDraftVersionThumbnailAsync(string chartKey)
     {
         var restRequest = new RestRequest("/charts/{key}/version/draft/thumbnail", Method.Get)
             .AddUrlSegment("key", chartKey);
-        var restResponse = _restClient.Execute<object>(restRequest);
+        var restResponse = await _restClient.ExecuteAsync<object>(restRequest);
         AssertOk(restResponse);
         return restResponse.RawBytes;
     }
 
-    public void PublishDraftVersion(string chartKey)
+    public async Task PublishDraftVersionAsync(string chartKey)
     {
         var restRequest = new RestRequest("/charts/{key}/version/draft/actions/publish", Method.Post)
             .AddUrlSegment("key", chartKey);
-        AssertOk(_restClient.Execute<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
     }
 
-    public void DiscardDraftVersion(string chartKey)
+    public async Task DiscardDraftVersionAsync(string chartKey)
     {
         var restRequest = new RestRequest("/charts/{key}/version/draft/actions/discard", Method.Post)
             .AddUrlSegment("key", chartKey);
-        AssertOk(_restClient.Execute<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
     }
 
-    public ChartValidationResult ValidatePublishedVersion(string chartKey)
+    public async Task<ChartValidationResult> ValidatePublishedVersionAsync(string chartKey)
     {
         var restRequest = new RestRequest("/charts/{key}/version/published/actions/validate", Method.Post)
             .AddUrlSegment("key",chartKey);
-        return AssertOk(_restClient.Execute<ChartValidationResult>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<ChartValidationResult>(restRequest));
     }
 
-    public ChartValidationResult ValidateDraftVersion(string chartKey)
+    public async Task<ChartValidationResult> ValidateDraftVersionAsync(string chartKey)
     {
         var restRequest = new RestRequest("/charts/{key}/version/draft/actions/validate", Method.Post)
             .AddUrlSegment("key",chartKey);
-        return AssertOk(_restClient.Execute<ChartValidationResult>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<ChartValidationResult>(restRequest));
     }
 
-    public IEnumerable<Chart> ListAll(string filter = null, string tag = null, bool? expandEvents = null, bool? withValidation = false)
+    public IAsyncEnumerable<Chart> ListAllAsync(string filter = null, string tag = null, bool? expandEvents = null, bool? withValidation = false)
     {
         return List().All(ChartListParams(filter, tag, expandEvents, withValidation));
     }
 
-    public Page<Chart> ListFirstPage(string filter = null, string tag = null, bool? expandEvents = false, int? pageSize = null, bool? withValidation = false)
+    public async Task<Page<Chart>> ListFirstPageAsync(string filter = null, string tag = null, bool? expandEvents = false, int? pageSize = null, bool? withValidation = false)
     {
-        return List().FirstPage(ChartListParams(filter, tag, expandEvents, withValidation), pageSize);
+        return await List().FirstPage(ChartListParams(filter, tag, expandEvents, withValidation), pageSize);
     }
 
-    public Page<Chart> ListPageAfter(long id, string filter = null, string tag = null, bool? expandEvents = false, int? pageSize = null, bool? withValidation = false)
+    public async Task<Page<Chart>> ListPageAfterAsync(long id, string filter = null, string tag = null, bool? expandEvents = false, int? pageSize = null, bool? withValidation = false)
     {
-        return List().PageAfter(id, ChartListParams(filter, tag, expandEvents, withValidation), pageSize);
+        return await List().PageAfter(id, ChartListParams(filter, tag, expandEvents, withValidation), pageSize);
     }
 
-    public Page<Chart> ListPageBefore(long id, string filter = null, string tag = null, bool? expandEvents = false, int? pageSize = null, bool? withValidation = false)
+    public async Task<Page<Chart>> ListPageBeforeAsync(long id, string filter = null, string tag = null, bool? expandEvents = false, int? pageSize = null, bool? withValidation = false)
     {
-        return List().PageBefore(id, ChartListParams(filter, tag, expandEvents, withValidation), pageSize);
+        return await List().PageBefore(id, ChartListParams(filter, tag, expandEvents, withValidation), pageSize);
     }
 
     private Dictionary<string, object> ChartListParams(string filter, string tag, bool? expandEvents, bool? withValidation = false)

--- a/SeatsioDotNet/Charts/Charts.cs
+++ b/SeatsioDotNet/Charts/Charts.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 using RestSharp;
 using SeatsioDotNet.Util;
@@ -20,7 +21,7 @@ public class Charts
         Archive = new Lister<Chart>(new PageFetcher<Chart>(_restClient, "/charts/archive"));
     }
 
-    public async Task<Chart> CreateAsync(string name = null, string venueType = null, IEnumerable<Category> categories = null)
+    public async Task<Chart> CreateAsync(string name = null, string venueType = null, IEnumerable<Category> categories = null, CancellationToken cancellationToken = default)
     {
         var requestBody = new Dictionary<string, object>();
 
@@ -41,10 +42,10 @@ public class Charts
 
         var restRequest = new RestRequest("/charts", Method.Post)
             .AddJsonBody(requestBody);
-        return AssertOk(await _restClient.ExecuteAsync<Chart>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Chart>(restRequest, cancellationToken));
     }
 
-    public async Task UpdateAsync(string chartKey, string name = null, IEnumerable<Category> categories = null)
+    public async Task UpdateAsync(string chartKey, string name = null, IEnumerable<Category> categories = null, CancellationToken cancellationToken = default)
     {
         var requestBody = new Dictionary<string, object>();
 
@@ -61,29 +62,29 @@ public class Charts
         var restRequest = new RestRequest("/charts/{key}", Method.Post)
             .AddUrlSegment("key", chartKey)
             .AddJsonBody(requestBody);
-        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest, cancellationToken));
     }
         
-    public async Task AddCategoryAsync(string chartKey, Category category)
+    public async Task AddCategoryAsync(string chartKey, Category category, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/charts/{chartKey}/categories", Method.Post)
             .AddUrlSegment("chartKey", chartKey)
             .AddJsonBody(category.AsDictionary());
-        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest, cancellationToken));
     }
 
-    public async Task RemoveCategoryAsync(string chartKey, object categoryKey)
+    public async Task RemoveCategoryAsync(string chartKey, object categoryKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/charts/{chartKey}/categories/{categoryKey}", Method.Delete)
             .AddUrlSegment("chartKey", chartKey)
             .AddUrlSegment("categoryKey", categoryKey.ToString());
-        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest, cancellationToken));
     }
 
-    public async Task<IEnumerable<Category>> ListCategoriesAsync(string chartKey)
+    public async Task<IEnumerable<Category>> ListCategoriesAsync(string chartKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest($"/charts/{chartKey}/categories", Method.Get);
-        return (await _restClient.ExecuteAsync<CategoryList>(restRequest)).Data.List;
+        return (await _restClient.ExecuteAsync<CategoryList>(restRequest, cancellationToken)).Data.List;
     }
 
     private class CategoryList
@@ -92,54 +93,54 @@ public class Charts
         public IEnumerable<Category> List { get; set; }
     }
 
-    public async Task<Chart> CopyAsync(string chartKey)
+    public async Task<Chart> CopyAsync(string chartKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/charts/{key}/version/published/actions/copy", Method.Post)
             .AddUrlSegment("key", chartKey);
-        return AssertOk(await _restClient.ExecuteAsync<Chart>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Chart>(restRequest, cancellationToken));
     }
 
-    public async Task<Chart> CopyToWorkspaceAsync(string chartKey, string toWorkspaceKey)
+    public async Task<Chart> CopyToWorkspaceAsync(string chartKey, string toWorkspaceKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/charts/{key}/version/published/actions/copy-to-workspace/{toWorkspaceKey}", Method.Post)
             .AddUrlSegment("key", chartKey)
             .AddUrlSegment("toWorkspaceKey", toWorkspaceKey);
-        return AssertOk(await _restClient.ExecuteAsync<Chart>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Chart>(restRequest, cancellationToken));
     }
         
-    public async Task<Chart> CopyToWorkspaceAsync(string chartKey, string fromWorkspaceKey, string toWorkspaceKey)
+    public async Task<Chart> CopyToWorkspaceAsync(string chartKey, string fromWorkspaceKey, string toWorkspaceKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest($"/charts/{chartKey}/version/published/actions/copy/from/{fromWorkspaceKey}/to/{toWorkspaceKey}", Method.Post)
             .AddUrlSegment("chartKey", chartKey)
             .AddUrlSegment("fromWorkspaceKey", fromWorkspaceKey)
             .AddUrlSegment("toWorkspaceKey", toWorkspaceKey);
-        return AssertOk(await _restClient.ExecuteAsync<Chart>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Chart>(restRequest, cancellationToken));
     }
 
-    public async Task<Chart> CopyDraftVersionAsync(string chartKey)
+    public async Task<Chart> CopyDraftVersionAsync(string chartKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/charts/{key}/version/draft/actions/copy", Method.Post)
             .AddUrlSegment("key", chartKey);
-        return AssertOk(await _restClient.ExecuteAsync<Chart>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Chart>(restRequest, cancellationToken));
     }
 
-    public async Task AddTagAsync(string chartKey, string tag)
+    public async Task AddTagAsync(string chartKey, string tag, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/charts/{key}/tags/{tag}", Method.Post)
             .AddUrlSegment("key", chartKey)
             .AddUrlSegment("tag", tag);
-        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest, cancellationToken));
     }
 
-    public async Task RemoveTagAsync(string chartKey, string tag)
+    public async Task RemoveTagAsync(string chartKey, string tag, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/charts/{key}/tags/{tag}", Method.Delete)
             .AddUrlSegment("key", chartKey)
             .AddUrlSegment("tag", tag);
-        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest, cancellationToken));
     }
         
-    public async Task<Chart> RetrieveAsync(string chartKey, bool? expandEvents = null)
+    public async Task<Chart> RetrieveAsync(string chartKey, bool? expandEvents = null, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/charts/{key}", Method.Get)
             .AddUrlSegment("key", chartKey);
@@ -149,13 +150,13 @@ public class Charts
             restRequest.AddQueryParameter("expand", "events");
         }
 
-        return AssertOk(await _restClient.ExecuteAsync<Chart>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Chart>(restRequest, cancellationToken));
     }
 
-    public async Task<IEnumerable<string>> ListAllTagsAsync()
+    public async Task<IEnumerable<string>> ListAllTagsAsync(CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/charts/tags", Method.Get);
-        return AssertOk(await _restClient.ExecuteAsync<Tags>(restRequest)).List;
+        return AssertOk(await _restClient.ExecuteAsync<Tags>(restRequest, cancellationToken)).List;
     }
 
     private class Tags
@@ -164,98 +165,98 @@ public class Charts
         public IEnumerable<string> List { get; set; }
     }
 
-    public async Task MoveToArchiveAsync(string chartKey)
+    public async Task MoveToArchiveAsync(string chartKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/charts/{key}/actions/move-to-archive", Method.Post)
             .AddUrlSegment("key", chartKey);
-        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest, cancellationToken));
     }
 
-    public async Task MoveOutOfArchiveAsync(string chartKey)
+    public async Task MoveOutOfArchiveAsync(string chartKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/charts/{key}/actions/move-out-of-archive", Method.Post)
             .AddUrlSegment("key", chartKey);
-        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest, cancellationToken));
     }
 
-    public async Task<Drawing> RetrievePublishedVersionAsync(string chartKey)
+    public async Task<Drawing> RetrievePublishedVersionAsync(string chartKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/charts/{key}/version/published", Method.Get)
             .AddUrlSegment("key", chartKey);
-        return AssertOk(await _restClient.ExecuteAsync<Drawing>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Drawing>(restRequest, cancellationToken));
     }
 
-    public async Task<byte[]> RetrievePublishedVersionThumbnailAsync(string chartKey)
+    public async Task<byte[]> RetrievePublishedVersionThumbnailAsync(string chartKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/charts/{key}/version/published/thumbnail", Method.Get)
             .AddUrlSegment("key", chartKey);
-        var restResponse = await _restClient.ExecuteAsync<object>(restRequest);
+        var restResponse = await _restClient.ExecuteAsync<object>(restRequest, cancellationToken);
         AssertOk(restResponse);
         return restResponse.RawBytes;
     }
 
-    public async Task<Drawing> RetrieveDraftVersionAsync(string chartKey)
+    public async Task<Drawing> RetrieveDraftVersionAsync(string chartKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/charts/{key}/version/draft", Method.Get)
             .AddUrlSegment("key", chartKey);
-        return AssertOk(await _restClient.ExecuteAsync<Drawing>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Drawing>(restRequest, cancellationToken));
     }
 
-    public async Task<byte[]> RetrieveDraftVersionThumbnailAsync(string chartKey)
+    public async Task<byte[]> RetrieveDraftVersionThumbnailAsync(string chartKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/charts/{key}/version/draft/thumbnail", Method.Get)
             .AddUrlSegment("key", chartKey);
-        var restResponse = await _restClient.ExecuteAsync<object>(restRequest);
+        var restResponse = await _restClient.ExecuteAsync<object>(restRequest, cancellationToken);
         AssertOk(restResponse);
         return restResponse.RawBytes;
     }
 
-    public async Task PublishDraftVersionAsync(string chartKey)
+    public async Task PublishDraftVersionAsync(string chartKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/charts/{key}/version/draft/actions/publish", Method.Post)
             .AddUrlSegment("key", chartKey);
-        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest, cancellationToken));
     }
 
-    public async Task DiscardDraftVersionAsync(string chartKey)
+    public async Task DiscardDraftVersionAsync(string chartKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/charts/{key}/version/draft/actions/discard", Method.Post)
             .AddUrlSegment("key", chartKey);
-        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest, cancellationToken));
     }
 
-    public async Task<ChartValidationResult> ValidatePublishedVersionAsync(string chartKey)
+    public async Task<ChartValidationResult> ValidatePublishedVersionAsync(string chartKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/charts/{key}/version/published/actions/validate", Method.Post)
             .AddUrlSegment("key",chartKey);
-        return AssertOk(await _restClient.ExecuteAsync<ChartValidationResult>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<ChartValidationResult>(restRequest, cancellationToken));
     }
 
-    public async Task<ChartValidationResult> ValidateDraftVersionAsync(string chartKey)
+    public async Task<ChartValidationResult> ValidateDraftVersionAsync(string chartKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/charts/{key}/version/draft/actions/validate", Method.Post)
             .AddUrlSegment("key",chartKey);
-        return AssertOk(await _restClient.ExecuteAsync<ChartValidationResult>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<ChartValidationResult>(restRequest, cancellationToken));
     }
 
     public IAsyncEnumerable<Chart> ListAllAsync(string filter = null, string tag = null, bool? expandEvents = null, bool? withValidation = false)
     {
-        return List().All(ChartListParams(filter, tag, expandEvents, withValidation));
+        return List().AllAsync(ChartListParams(filter, tag, expandEvents, withValidation));
     }
 
-    public async Task<Page<Chart>> ListFirstPageAsync(string filter = null, string tag = null, bool? expandEvents = false, int? pageSize = null, bool? withValidation = false)
+    public async Task<Page<Chart>> ListFirstPageAsync(string filter = null, string tag = null, bool? expandEvents = false, int? pageSize = null, bool? withValidation = false, CancellationToken cancellationToken = default)
     {
-        return await List().FirstPage(ChartListParams(filter, tag, expandEvents, withValidation), pageSize);
+        return await List().FirstPageAsync(ChartListParams(filter, tag, expandEvents, withValidation), pageSize, cancellationToken);
     }
 
-    public async Task<Page<Chart>> ListPageAfterAsync(long id, string filter = null, string tag = null, bool? expandEvents = false, int? pageSize = null, bool? withValidation = false)
+    public async Task<Page<Chart>> ListPageAfterAsync(long id, string filter = null, string tag = null, bool? expandEvents = false, int? pageSize = null, bool? withValidation = false, CancellationToken cancellationToken = default)
     {
-        return await List().PageAfter(id, ChartListParams(filter, tag, expandEvents, withValidation), pageSize);
+        return await List().PageAfterAsync(id, ChartListParams(filter, tag, expandEvents, withValidation), pageSize, cancellationToken);
     }
 
-    public async Task<Page<Chart>> ListPageBeforeAsync(long id, string filter = null, string tag = null, bool? expandEvents = false, int? pageSize = null, bool? withValidation = false)
+    public async Task<Page<Chart>> ListPageBeforeAsync(long id, string filter = null, string tag = null, bool? expandEvents = false, int? pageSize = null, bool? withValidation = false, CancellationToken cancellationToken = default)
     {
-        return await List().PageBefore(id, ChartListParams(filter, tag, expandEvents, withValidation), pageSize);
+        return await List().PageBeforeAsync(id, ChartListParams(filter, tag, expandEvents, withValidation), pageSize, cancellationToken);
     }
 
     private Dictionary<string, object> ChartListParams(string filter, string tag, bool? expandEvents, bool? withValidation = false)

--- a/SeatsioDotNet/EventLog/EventLog.cs
+++ b/SeatsioDotNet/EventLog/EventLog.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using RestSharp;
 using SeatsioDotNet.Util;
 
@@ -13,24 +14,24 @@ public class EventLog
         _restClient = restClient;
     }
 
-    public IEnumerable<EventLogItem> ListAll()
+    public IAsyncEnumerable<EventLogItem> ListAllAsync()
     {
         return ParametrizedList().All();
     }
 
-    public Page<EventLogItem> ListFirstPage(int? pageSize = null)
+    public async Task<Page<EventLogItem>> ListFirstPage(int? pageSize = null)
     {
-        return ParametrizedList().FirstPage(pageSize);
+        return await ParametrizedList().FirstPage(pageSize);
     }
 
-    public Page<EventLogItem> ListPageAfter(long id, int? pageSize = null)
+    public async Task<Page<EventLogItem>> ListPageAfter(long id, int? pageSize = null)
     {
-        return ParametrizedList().PageAfter(id, pageSize);
+        return await ParametrizedList().PageAfter(id, pageSize);
     }
 
-    public Page<EventLogItem> ListPageBefore(long id, int? pageSize = null)
+    public async Task<Page<EventLogItem>> ListPageBefore(long id, int? pageSize = null)
     {
-        return ParametrizedList().PageBefore(id, pageSize);
+        return await ParametrizedList().PageBefore(id, pageSize);
     }
 
     private EventLogItemLister ParametrizedList()

--- a/SeatsioDotNet/EventLog/EventLog.cs
+++ b/SeatsioDotNet/EventLog/EventLog.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using RestSharp;
 using SeatsioDotNet.Util;
@@ -16,22 +17,22 @@ public class EventLog
 
     public IAsyncEnumerable<EventLogItem> ListAllAsync()
     {
-        return ParametrizedList().All();
+        return ParametrizedList().AllAsync();
     }
 
-    public async Task<Page<EventLogItem>> ListFirstPage(int? pageSize = null)
+    public async Task<Page<EventLogItem>> ListFirstPageAsync(int? pageSize = null, CancellationToken cancellationToken = default)
     {
-        return await ParametrizedList().FirstPage(pageSize);
+        return await ParametrizedList().FirstPageAsync(pageSize, cancellationToken);
     }
 
-    public async Task<Page<EventLogItem>> ListPageAfter(long id, int? pageSize = null)
+    public async Task<Page<EventLogItem>> ListPageAfterAsync(long id, int? pageSize = null, CancellationToken cancellationToken = default)
     {
-        return await ParametrizedList().PageAfter(id, pageSize);
+        return await ParametrizedList().PageAfterAsync(id, pageSize, cancellationToken);
     }
 
-    public async Task<Page<EventLogItem>> ListPageBefore(long id, int? pageSize = null)
+    public async Task<Page<EventLogItem>> ListPageBeforeAsync(long id, int? pageSize = null, CancellationToken cancellationToken = default)
     {
-        return await ParametrizedList().PageBefore(id, pageSize);
+        return await ParametrizedList().PageBeforeAsync(id, pageSize, cancellationToken);
     }
 
     private EventLogItemLister ParametrizedList()

--- a/SeatsioDotNet/EventLog/EventLogItemLister.cs
+++ b/SeatsioDotNet/EventLog/EventLogItemLister.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using SeatsioDotNet.Util;
 
@@ -13,23 +14,23 @@ public class EventLogItemLister
         _pageFetcher = pageFetcher;
     }
 
-    public IAsyncEnumerable<EventLogItem> All()
+    public IAsyncEnumerable<EventLogItem> AllAsync()
     {
         return new PagedEnumerable<EventLogItem>(_pageFetcher, null);
     }
 
-    public async Task<Page<EventLogItem>> FirstPage(int? pageSize = null)
+    public async Task<Page<EventLogItem>> FirstPageAsync(int? pageSize = null, CancellationToken cancellationToken = default)
     {
-        return await _pageFetcher.FetchFirstPageAsync(null, pageSize);
+        return await _pageFetcher.FetchFirstPageAsync(null, pageSize, cancellationToken);
     }
 
-    public async Task<Page<EventLogItem>> PageAfter(long id, int? pageSize = null)
+    public async Task<Page<EventLogItem>> PageAfterAsync(long id, int? pageSize = null, CancellationToken cancellationToken = default)
     {
-        return await _pageFetcher.FetchAfterAsync(id, null, pageSize);
+        return await _pageFetcher.FetchAfterAsync(id, null, pageSize, cancellationToken);
     }
 
-    public async Task<Page<EventLogItem>> PageBefore(long id, int? pageSize = null)
+    public async Task<Page<EventLogItem>> PageBeforeAsync(long id, int? pageSize = null, CancellationToken cancellationToken = default)
     {
-        return await _pageFetcher.FetchBeforeAsync(id, null, pageSize);
+        return await _pageFetcher.FetchBeforeAsync(id, null, pageSize, cancellationToken);
     }
 }

--- a/SeatsioDotNet/EventLog/EventLogItemLister.cs
+++ b/SeatsioDotNet/EventLog/EventLogItemLister.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using SeatsioDotNet.Util;
 
 namespace SeatsioDotNet.EventLog;
@@ -12,23 +13,23 @@ public class EventLogItemLister
         _pageFetcher = pageFetcher;
     }
 
-    public IEnumerable<EventLogItem> All()
+    public IAsyncEnumerable<EventLogItem> All()
     {
         return new PagedEnumerable<EventLogItem>(_pageFetcher, null);
     }
 
-    public Page<EventLogItem> FirstPage(int? pageSize = null)
+    public async Task<Page<EventLogItem>> FirstPage(int? pageSize = null)
     {
-        return _pageFetcher.FetchFirstPage(null, pageSize);
+        return await _pageFetcher.FetchFirstPageAsync(null, pageSize);
     }
 
-    public Page<EventLogItem> PageAfter(long id, int? pageSize = null)
+    public async Task<Page<EventLogItem>> PageAfter(long id, int? pageSize = null)
     {
-        return _pageFetcher.FetchAfter(id, null, pageSize);
+        return await _pageFetcher.FetchAfterAsync(id, null, pageSize);
     }
 
-    public Page<EventLogItem> PageBefore(long id, int? pageSize = null)
+    public async Task<Page<EventLogItem>> PageBefore(long id, int? pageSize = null)
     {
-        return _pageFetcher.FetchBefore(id, null, pageSize);
+        return await _pageFetcher.FetchBeforeAsync(id, null, pageSize);
     }
 }

--- a/SeatsioDotNet/Events/Channels.cs
+++ b/SeatsioDotNet/Events/Channels.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using RestSharp;
 using static SeatsioDotNet.Util.RestUtil;
 
@@ -13,13 +14,13 @@ public class Channels
         _restClient = restClient;
     }
 
-    public void Replace(string eventKey, List<Channel> channels)
+    public async Task ReplaceAsync(string eventKey, List<Channel> channels)
     {
         var requestBody = ReplaceChannelsRequest(channels);
         var restRequest = new RestRequest("/events/{key}/channels/replace", Method.Post)
             .AddUrlSegment("key", eventKey)
             .AddJsonBody(requestBody);
-        AssertOk(_restClient.Execute<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
     }
 
     private Dictionary<string, object> ReplaceChannelsRequest(List<Channel> channels)
@@ -29,7 +30,7 @@ public class Channels
         return request;
     }
 
-    public void Add(string eventKey, string channelKey, string name, string color, int? index, string[] objects)
+    public async Task AddAsync(string eventKey, string channelKey, string name, string color, int? index, string[] objects)
     {
         var body = new Dictionary<string, object>();
         body.Add("key", channelKey);
@@ -40,10 +41,10 @@ public class Channels
         var restRequest = new RestRequest("/events/{key}/channels", Method.Post)
             .AddUrlSegment("key", eventKey)
             .AddJsonBody(body);
-        AssertOk(_restClient.Execute<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
     }
 
-    public void Add(string eventKey, ChannelCreationParams[] channelCreationParams)
+    public async Task AddAsync(string eventKey, ChannelCreationParams[] channelCreationParams)
     {
         var channels = new List<Dictionary<string, object>>();
         foreach (var param in channelCreationParams)
@@ -80,18 +81,18 @@ public class Channels
         var restRequest = new RestRequest("/events/{key}/channels", Method.Post)
             .AddUrlSegment("key", eventKey)
             .AddJsonBody(channels);
-        AssertOk(_restClient.Execute<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
     }
 
-    public void Remove(string eventKey, string channelKey)
+    public async Task RemoveAsync(string eventKey, string channelKey)
     {
         var restRequest = new RestRequest("/events/{eventKey}/channels/{channelKey}", Method.Delete)
             .AddUrlSegment("eventKey", eventKey)
             .AddUrlSegment("channelKey", channelKey);
-        AssertOk(_restClient.Execute<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
     }
 
-    public void AddObjects(string eventKey, string channelKey, string[] objects)
+    public async Task AddObjectsAsync(string eventKey, string channelKey, string[] objects)
     {
         var body = new Dictionary<string, object>();
         body.Add("objects", objects);
@@ -99,10 +100,10 @@ public class Channels
             .AddUrlSegment("eventKey", eventKey)
             .AddUrlSegment("channelKey", channelKey)
             .AddJsonBody(body);
-        AssertOk(_restClient.Execute<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
     }
 
-    public void RemoveObjects(string eventKey, string channelKey, string[] objects)
+    public async Task RemoveObjectsAsync(string eventKey, string channelKey, string[] objects)
     {
         var body = new Dictionary<string, object>();
         body.Add("objects", objects);
@@ -110,10 +111,10 @@ public class Channels
             .AddUrlSegment("eventKey", eventKey)
             .AddUrlSegment("channelKey", channelKey)
             .AddJsonBody(body);
-        AssertOk(_restClient.Execute<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
     }
 
-    public void Update(string eventKey, string channelKey, string channelName, string color, string[] objects)
+    public async Task UpdateAsync(string eventKey, string channelKey, string channelName, string color, string[] objects)
     {
         var body = new Dictionary<string, object>();
         if (channelName != null) body.Add("name", channelName);
@@ -123,6 +124,6 @@ public class Channels
             .AddUrlSegment("eventKey", eventKey)
             .AddUrlSegment("channelKey", channelKey)
             .AddJsonBody(body);
-        AssertOk(_restClient.Execute<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
     }
 }

--- a/SeatsioDotNet/Events/Channels.cs
+++ b/SeatsioDotNet/Events/Channels.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using RestSharp;
 using static SeatsioDotNet.Util.RestUtil;
@@ -14,13 +15,13 @@ public class Channels
         _restClient = restClient;
     }
 
-    public async Task ReplaceAsync(string eventKey, List<Channel> channels)
+    public async Task ReplaceAsync(string eventKey, List<Channel> channels, CancellationToken cancellationToken = default)
     {
         var requestBody = ReplaceChannelsRequest(channels);
         var restRequest = new RestRequest("/events/{key}/channels/replace", Method.Post)
             .AddUrlSegment("key", eventKey)
             .AddJsonBody(requestBody);
-        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest, cancellationToken));
     }
 
     private Dictionary<string, object> ReplaceChannelsRequest(List<Channel> channels)
@@ -30,7 +31,7 @@ public class Channels
         return request;
     }
 
-    public async Task AddAsync(string eventKey, string channelKey, string name, string color, int? index, string[] objects)
+    public async Task AddAsync(string eventKey, string channelKey, string name, string color, int? index, string[] objects, CancellationToken cancellationToken = default)
     {
         var body = new Dictionary<string, object>();
         body.Add("key", channelKey);
@@ -41,10 +42,10 @@ public class Channels
         var restRequest = new RestRequest("/events/{key}/channels", Method.Post)
             .AddUrlSegment("key", eventKey)
             .AddJsonBody(body);
-        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest, cancellationToken));
     }
 
-    public async Task AddAsync(string eventKey, ChannelCreationParams[] channelCreationParams)
+    public async Task AddAsync(string eventKey, ChannelCreationParams[] channelCreationParams, CancellationToken cancellationToken = default)
     {
         var channels = new List<Dictionary<string, object>>();
         foreach (var param in channelCreationParams)
@@ -81,18 +82,18 @@ public class Channels
         var restRequest = new RestRequest("/events/{key}/channels", Method.Post)
             .AddUrlSegment("key", eventKey)
             .AddJsonBody(channels);
-        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest, cancellationToken));
     }
 
-    public async Task RemoveAsync(string eventKey, string channelKey)
+    public async Task RemoveAsync(string eventKey, string channelKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/events/{eventKey}/channels/{channelKey}", Method.Delete)
             .AddUrlSegment("eventKey", eventKey)
             .AddUrlSegment("channelKey", channelKey);
-        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest, cancellationToken));
     }
 
-    public async Task AddObjectsAsync(string eventKey, string channelKey, string[] objects)
+    public async Task AddObjectsAsync(string eventKey, string channelKey, string[] objects, CancellationToken cancellationToken = default)
     {
         var body = new Dictionary<string, object>();
         body.Add("objects", objects);
@@ -100,10 +101,10 @@ public class Channels
             .AddUrlSegment("eventKey", eventKey)
             .AddUrlSegment("channelKey", channelKey)
             .AddJsonBody(body);
-        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest, cancellationToken));
     }
 
-    public async Task RemoveObjectsAsync(string eventKey, string channelKey, string[] objects)
+    public async Task RemoveObjectsAsync(string eventKey, string channelKey, string[] objects, CancellationToken cancellationToken = default)
     {
         var body = new Dictionary<string, object>();
         body.Add("objects", objects);
@@ -111,10 +112,10 @@ public class Channels
             .AddUrlSegment("eventKey", eventKey)
             .AddUrlSegment("channelKey", channelKey)
             .AddJsonBody(body);
-        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest, cancellationToken));
     }
 
-    public async Task UpdateAsync(string eventKey, string channelKey, string channelName, string color, string[] objects)
+    public async Task UpdateAsync(string eventKey, string channelKey, string channelName, string color, string[] objects, CancellationToken cancellationToken = default)
     {
         var body = new Dictionary<string, object>();
         if (channelName != null) body.Add("name", channelName);
@@ -124,6 +125,6 @@ public class Channels
             .AddUrlSegment("eventKey", eventKey)
             .AddUrlSegment("channelKey", channelKey)
             .AddJsonBody(body);
-        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest, cancellationToken));
     }
 }

--- a/SeatsioDotNet/Events/Events.cs
+++ b/SeatsioDotNet/Events/Events.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using RestSharp;
 using SeatsioDotNet.EventReports;
@@ -20,12 +21,12 @@ public class Events
         Channels = new Channels(restClient);
     }
 
-    public async Task<Event> CreateAsync(string chartKey)
+    public async Task<Event> CreateAsync(string chartKey, CancellationToken cancellationToken = default)
     {
-        return await CreateAsync(chartKey, new CreateEventParams());
+        return await CreateAsync(chartKey, new CreateEventParams(), cancellationToken);
     }
 
-    public async Task<Event> CreateAsync(string chartKey, CreateEventParams p)
+    public async Task<Event> CreateAsync(string chartKey, CreateEventParams p, CancellationToken cancellationToken = default)
     {
         var requestBody = new Dictionary<string, object>();
         requestBody.Add("chartKey", chartKey);
@@ -71,10 +72,10 @@ public class Events
         }
 
         var restRequest = new RestRequest("/events", Method.Post).AddJsonBody(requestBody);
-        return AssertOk(await _restClient.ExecuteAsync<Event>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Event>(restRequest, cancellationToken));
     }
 
-    public async Task<Event[]> CreateAsync(string chartKey, CreateEventParams[] eventCreationParams)
+    public async Task<Event[]> CreateAsync(string chartKey, CreateEventParams[] eventCreationParams, CancellationToken cancellationToken = default)
     {
         Dictionary<string, object> requestBody = new Dictionary<string, object>();
         requestBody.Add("chartKey", chartKey);
@@ -127,10 +128,10 @@ public class Events
 
         requestBody.Add("events", events.ToArray());
         var restRequest = new RestRequest("/events/actions/create-multiple", Method.Post).AddJsonBody(requestBody);
-        return AssertOk(await _restClient.ExecuteAsync<MultipleEvents>(restRequest)).events.ToArray();
+        return AssertOk(await _restClient.ExecuteAsync<MultipleEvents>(restRequest, cancellationToken)).events.ToArray();
     }
 
-    public async Task UpdateAsync(string eventKey, UpdateEventParams p)
+    public async Task UpdateAsync(string eventKey, UpdateEventParams p, CancellationToken cancellationToken = default)
     {
         Dictionary<string, object> requestBody = new Dictionary<string, object>();
 
@@ -177,30 +178,30 @@ public class Events
         var restRequest = new RestRequest("/events/{key}", Method.Post)
             .AddUrlSegment("key", eventKey)
             .AddJsonBody(requestBody);
-        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest, cancellationToken));
     }
 
-    public async Task DeleteAsync(string eventKey)
+    public async Task DeleteAsync(string eventKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/events/{key}", Method.Delete)
             .AddUrlSegment("key", eventKey);
-        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest, cancellationToken));
     }
 
-    public async Task<Event> RetrieveAsync(string eventKey)
+    public async Task<Event> RetrieveAsync(string eventKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/events/{key}")
             .AddUrlSegment("key", eventKey);
-        return AssertOk(await _restClient.ExecuteAsync<Event>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Event>(restRequest, cancellationToken));
     }
 
-    public async Task<EventObjectInfo> RetrieveObjectInfoAsync(string eventKey, string objectLabel)
+    public async Task<EventObjectInfo> RetrieveObjectInfoAsync(string eventKey, string objectLabel, CancellationToken cancellationToken = default)
     {
-        var result = await RetrieveObjectInfosAsync(eventKey, new[] {objectLabel});
+        var result = await RetrieveObjectInfosAsync(eventKey, new[] {objectLabel}, cancellationToken);
         return result[objectLabel];
     }
 
-    public async Task<Dictionary<string, EventObjectInfo>> RetrieveObjectInfosAsync(string eventKey, string[] objectLabels)
+    public async Task<Dictionary<string, EventObjectInfo>> RetrieveObjectInfosAsync(string eventKey, string[] objectLabels, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/events/{key}/objects")
             .AddUrlSegment("key", eventKey);
@@ -210,154 +211,154 @@ public class Events
             restRequest.AddQueryParameter("label", objectLabel);
         }
 
-        return AssertOk(await _restClient.ExecuteAsync<Dictionary<string, EventObjectInfo>>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Dictionary<string, EventObjectInfo>>(restRequest, cancellationToken));
     }
 
     public async Task<ChangeObjectStatusResult> BookAsync(string eventKey, IEnumerable<string> objects, string holdToken = null,
-        string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null)
+        string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null, CancellationToken cancellationToken = default)
     {
         return await ChangeObjectStatusAsync(eventKey, objects, EventObjectInfo.Booked, holdToken, orderId, keepExtraData,
-            ignoreChannels, channelKeys);
+            ignoreChannels, channelKeys, cancellationToken:cancellationToken);
     }
 
     public async Task<ChangeObjectStatusResult> BookAsync(string[] eventKeys, IEnumerable<string> objects, string holdToken = null,
-        string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null)
+        string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null, CancellationToken cancellationToken = default)
     {
         return await ChangeObjectStatusAsync(eventKeys, objects, EventObjectInfo.Booked, holdToken, orderId, keepExtraData,
-            ignoreChannels, channelKeys);
+            ignoreChannels, channelKeys, cancellationToken);
     }
 
     public async Task<ChangeObjectStatusResult> BookAsync(string eventKey, IEnumerable<ObjectProperties> objects,
         string holdToken = null, string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null,
-        string[] channelKeys = null)
+        string[] channelKeys = null, CancellationToken cancellationToken = default)
     {
         return await ChangeObjectStatusAsync(eventKey, objects, EventObjectInfo.Booked, holdToken, orderId, keepExtraData,
-            ignoreChannels, channelKeys);
+            ignoreChannels, channelKeys, cancellationToken);
     }
 
     public async Task<ChangeObjectStatusResult> BookAsync(string[] eventKeys, IEnumerable<ObjectProperties> objects,
         string holdToken = null, string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null,
-        string[] channelKeys = null)
+        string[] channelKeys = null, CancellationToken cancellationToken = default)
     {
         return await ChangeObjectStatusAsync(eventKeys, objects, EventObjectInfo.Booked, holdToken, orderId, keepExtraData,
-            ignoreChannels, channelKeys);
+            ignoreChannels, channelKeys, cancellationToken:cancellationToken);
     }
 
     public async Task<BestAvailableResult> BookAsync(string eventKey, BestAvailable bestAvailable, string holdToken = null,
-        string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null)
+        string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null, CancellationToken cancellationToken = default)
     {
         return await ChangeObjectStatusAsync(eventKey, bestAvailable, EventObjectInfo.Booked, holdToken, orderId,
-            keepExtraData, ignoreChannels, channelKeys);
+            keepExtraData, ignoreChannels, channelKeys, cancellationToken);
     }
 
     public async Task<ChangeObjectStatusResult> ReleaseAsync(string eventKey, IEnumerable<string> objects, string holdToken = null,
-        string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null)
+        string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null, CancellationToken cancellationToken = default)
     {
         return await ChangeObjectStatusAsync(eventKey, objects, EventObjectInfo.Free, holdToken, orderId, keepExtraData,
-            ignoreChannels, channelKeys);
+            ignoreChannels, channelKeys, cancellationToken:cancellationToken);
     }
 
     public async Task<ChangeObjectStatusResult> ReleaseAsync(string[] eventKeys, IEnumerable<string> objects,
         string holdToken = null, string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null,
-        string[] channelKeys = null)
+        string[] channelKeys = null, CancellationToken cancellationToken = default)
     {
         return await ChangeObjectStatusAsync(eventKeys, objects, EventObjectInfo.Free, holdToken, orderId, keepExtraData,
-            ignoreChannels, channelKeys);
+            ignoreChannels, channelKeys, cancellationToken);
     }
 
     public async Task<ChangeObjectStatusResult> ReleaseAsync(string eventKey, IEnumerable<ObjectProperties> objects,
         string holdToken = null, string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null,
-        string[] channelKeys = null)
+        string[] channelKeys = null, CancellationToken cancellationToken = default)
     {
         return await ChangeObjectStatusAsync(eventKey, objects, EventObjectInfo.Free, holdToken, orderId, keepExtraData,
-            ignoreChannels, channelKeys);
+            ignoreChannels, channelKeys, cancellationToken);
     }
 
     public async Task<ChangeObjectStatusResult> ReleaseAsync(string[] eventKeys, IEnumerable<ObjectProperties> objects,
         string holdToken = null, string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null,
-        string[] channelKeys = null)
+        string[] channelKeys = null, CancellationToken cancellationToken = default)
     {
         return await ChangeObjectStatusAsync(eventKeys, objects, EventObjectInfo.Free, holdToken, orderId, keepExtraData,
-            ignoreChannels, channelKeys);
+            ignoreChannels, channelKeys, cancellationToken:cancellationToken);
     }
 
     public async Task<ChangeObjectStatusResult> HoldAsync(string eventKey, IEnumerable<string> objects, string holdToken,
-        string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null)
+        string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null, CancellationToken cancellationToken = default)
     {
         return await ChangeObjectStatusAsync(eventKey, objects, EventObjectInfo.Held, holdToken, orderId, keepExtraData,
-            ignoreChannels, channelKeys);
+            ignoreChannels, channelKeys, cancellationToken:cancellationToken);
     }
 
     public async Task<ChangeObjectStatusResult> HoldAsync(string[] eventKeys, IEnumerable<string> objects, string holdToken,
-        string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null)
+        string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null, CancellationToken cancellationToken = default)
     {
         return await ChangeObjectStatusAsync(eventKeys, objects, EventObjectInfo.Held, holdToken, orderId, keepExtraData,
-            ignoreChannels, channelKeys);
+            ignoreChannels, channelKeys, cancellationToken);
     }
 
     public async Task<ChangeObjectStatusResult> HoldAsync(string eventKey, IEnumerable<ObjectProperties> objects, string holdToken,
-        string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null)
+        string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null, CancellationToken cancellationToken = default)
     {
         return await ChangeObjectStatusAsync(eventKey, objects, EventObjectInfo.Held, holdToken, orderId, keepExtraData,
-            ignoreChannels, channelKeys);
+            ignoreChannels, channelKeys, cancellationToken);
     }
 
     public async Task<ChangeObjectStatusResult> HoldAsync(string[] eventKeys, IEnumerable<ObjectProperties> objects,
         string holdToken, string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null,
-        string[] channelKeys = null)
+        string[] channelKeys = null, CancellationToken cancellationToken = default)
     {
         return await ChangeObjectStatusAsync(eventKeys, objects, EventObjectInfo.Held, holdToken, orderId, keepExtraData,
-            ignoreChannels, channelKeys);
+            ignoreChannels, channelKeys, cancellationToken:cancellationToken);
     }
 
     public async Task<BestAvailableResult> HoldAsync(string eventKey, BestAvailable bestAvailable, string holdToken,
-        string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null)
+        string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null, CancellationToken cancellationToken = default)
     {
         return await ChangeObjectStatusAsync(eventKey, bestAvailable, EventObjectInfo.Held, holdToken, orderId, keepExtraData,
-            ignoreChannels, channelKeys);
+            ignoreChannels, channelKeys, cancellationToken);
     }
 
     public async Task<ChangeObjectStatusResult> ChangeObjectStatusAsync(string eventKey, IEnumerable<string> objects, string status,
         string holdToken = null, string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null,
         string[] channelKeys = null, string[] allowedPreviousStatuses = null,
-        string[] rejectedPreviousStatuses = null)
+        string[] rejectedPreviousStatuses = null, CancellationToken cancellationToken = default)
     {
         return await ChangeObjectStatusAsync(new[] {eventKey}, objects.Select(o => new ObjectProperties(o)), status, holdToken,
             orderId, keepExtraData, ignoreChannels, channelKeys, allowedPreviousStatuses,
-            rejectedPreviousStatuses);
+            rejectedPreviousStatuses, cancellationToken);
     }
 
     public async Task<ChangeObjectStatusResult> ChangeObjectStatusAsync(string eventKey, IEnumerable<ObjectProperties> objects,
         string status, string holdToken = null, string orderId = null, bool? keepExtraData = null,
-        bool? ignoreChannels = null, string[] channelKeys = null)
+        bool? ignoreChannels = null, string[] channelKeys = null, CancellationToken cancellationToken = default)
     {
         return await ChangeObjectStatusAsync(new[] {eventKey}, objects, status, holdToken, orderId, keepExtraData,
-            ignoreChannels, channelKeys);
+            ignoreChannels, channelKeys, cancellationToken:cancellationToken);
     }
 
     public async Task<ChangeObjectStatusResult> ChangeObjectStatusAsync(IEnumerable<string> events, IEnumerable<string> objects,
         string status, string holdToken = null, string orderId = null, bool? keepExtraData = null,
-        bool? ignoreChannels = null, string[] channelKeys = null)
+        bool? ignoreChannels = null, string[] channelKeys = null, CancellationToken cancellationToken = default)
     {
         return await ChangeObjectStatusAsync(events, objects.Select(o => new ObjectProperties(o)), status, holdToken, orderId,
-            keepExtraData, ignoreChannels, channelKeys);
+            keepExtraData, ignoreChannels, channelKeys, cancellationToken:cancellationToken);
     }
 
     public async Task<ChangeObjectStatusResult> ChangeObjectStatusAsync(IEnumerable<string> events,
         IEnumerable<ObjectProperties> objects, string status, string holdToken = null, string orderId = null,
         bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null,
         string[] allowedPreviousStatuses = null,
-        string[] rejectedPreviousStatuses = null)
+        string[] rejectedPreviousStatuses = null, CancellationToken cancellationToken = default)
     {
         var requestBody = ChangeObjectStatusRequest(events, objects, status, holdToken, orderId, keepExtraData,
             ignoreChannels, channelKeys, allowedPreviousStatuses, rejectedPreviousStatuses);
         var restRequest = new RestRequest("/events/groups/actions/change-object-status", Method.Post)
             .AddQueryParameter("expand", "objects")
             .AddJsonBody(requestBody);
-        return AssertOk(await _restClient.ExecuteAsync<ChangeObjectStatusResult>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<ChangeObjectStatusResult>(restRequest, cancellationToken));
     }
 
-    public async Task<List<ChangeObjectStatusResult>> ChangeObjectStatusAsync(StatusChangeRequest[] requests)
+    public async Task<List<ChangeObjectStatusResult>> ChangeObjectStatusAsync(StatusChangeRequest[] requests, CancellationToken cancellationToken = default)
     {
         var serializedRequests = requests.Select(r => ChangeObjectStatusRequest(r.EventKey, r.Objects, r.Status,
             r.HoldToken, r.OrderId, r.KeepExtraData, r.IgnoreChannels, r.ChannelKeys,
@@ -365,7 +366,7 @@ public class Events
         var restRequest = new RestRequest("/events/actions/change-object-status", Method.Post)
             .AddQueryParameter("expand", "objects")
             .AddJsonBody(new Dictionary<string, object> {{"statusChanges", serializedRequests}});
-        return AssertOk(await _restClient.ExecuteAsync<ChangeObjectStatusInBatchResult>(restRequest)).Results;
+        return AssertOk(await _restClient.ExecuteAsync<ChangeObjectStatusInBatchResult>(restRequest, cancellationToken)).Results;
     }
 
     private Dictionary<string, object> ChangeObjectStatusRequest(string evnt, IEnumerable<ObjectProperties> objects,
@@ -441,7 +442,7 @@ public class Events
 
     public async Task<BestAvailableResult> ChangeObjectStatusAsync(string eventKey, BestAvailable bestAvailable, string status,
         string holdToken = null, string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null,
-        string[] channelKeys = null)
+        string[] channelKeys = null, CancellationToken cancellationToken = default)
     {
         var requestBody = new Dictionary<string, object>()
         {
@@ -477,68 +478,68 @@ public class Events
         var restRequest = new RestRequest("/events/{key}/actions/change-object-status", Method.Post)
             .AddUrlSegment("key", eventKey)
             .AddJsonBody(requestBody);
-        return AssertOk(await _restClient.ExecuteAsync<BestAvailableResult>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<BestAvailableResult>(restRequest, cancellationToken));
     }
 
-    public async Task OverrideSeasonObjectStatusAsync(string eventKey, string[] objects)
+    public async Task OverrideSeasonObjectStatusAsync(string eventKey, string[] objects, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/events/{key}/actions/override-season-status", Method.Post)
             .AddUrlSegment("key", eventKey)
             .AddJsonBody(new {objects});
-        AssertOk(await _restClient.ExecuteAsync<BestAvailableResult>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<BestAvailableResult>(restRequest, cancellationToken));
     }  
     
-    public async Task UseSeasonObjectStatusAsync(string eventKey, string[] objects)
+    public async Task UseSeasonObjectStatusAsync(string eventKey, string[] objects, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/events/{key}/actions/use-season-status", Method.Post)
             .AddUrlSegment("key", eventKey)
             .AddJsonBody(new {objects});
-        AssertOk(await _restClient.ExecuteAsync<BestAvailableResult>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<BestAvailableResult>(restRequest, cancellationToken));
     }
 
-    public async Task UpdateExtraDataAsync(string eventKey, string objectLabel, Dictionary<string, object> extraData)
+    public async Task UpdateExtraDataAsync(string eventKey, string objectLabel, Dictionary<string, object> extraData, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/events/{key}/objects/{object}/actions/update-extra-data", Method.Post)
             .AddUrlSegment("key", eventKey)
             .AddUrlSegment("object", objectLabel)
             .AddJsonBody(new {extraData});
-        AssertOk(await _restClient.ExecuteAsync<BestAvailableResult>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<BestAvailableResult>(restRequest, cancellationToken));
     }
 
-    public async Task UpdateExtraDatasAsync(string eventKey, Dictionary<string, Dictionary<string, object>> extraData)
+    public async Task UpdateExtraDatasAsync(string eventKey, Dictionary<string, Dictionary<string, object>> extraData, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/events/{key}/actions/update-extra-data", Method.Post)
             .AddUrlSegment("key", eventKey)
             .AddParameter("application/json", JsonSerializer.Serialize(new {extraData}),
                 ParameterType.RequestBody); // default serializer doesn't convert extraData to JSON properly
-        AssertOk(await _restClient.ExecuteAsync<BestAvailableResult>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<BestAvailableResult>(restRequest, cancellationToken));
     }
 
     public async Task MarkAsForSaleAsync(string eventKey, IEnumerable<string> objects, Dictionary<string, int> areaPlaces,
-        IEnumerable<string> categories)
+        IEnumerable<string> categories, CancellationToken cancellationToken = default)
     {
         var requestBody = ForSaleRequest(objects, areaPlaces, categories);
         var restRequest = new RestRequest("/events/{key}/actions/mark-as-for-sale", Method.Post)
             .AddUrlSegment("key", eventKey)
             .AddJsonBody(requestBody);
-        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest, cancellationToken));
     }
 
     public async Task MarkAsNotForSaleAsync(string eventKey, IEnumerable<string> objects, Dictionary<string, int> areaPlaces,
-        IEnumerable<string> categories)
+        IEnumerable<string> categories, CancellationToken cancellationToken = default)
     {
         var requestBody = ForSaleRequest(objects, areaPlaces, categories);
         var restRequest = new RestRequest("/events/{key}/actions/mark-as-not-for-sale", Method.Post)
             .AddUrlSegment("key", eventKey)
             .AddJsonBody(requestBody);
-        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest, cancellationToken));
     }
 
-    public async Task MarkEverythingAsForSaleAsync(string eventKey)
+    public async Task MarkEverythingAsForSaleAsync(string eventKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/events/{key}/actions/mark-everything-as-for-sale", Method.Post)
             .AddUrlSegment("key", eventKey);
-        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest, cancellationToken));
     }
 
     private Dictionary<string, object> ForSaleRequest(IEnumerable<string> objects,

--- a/SeatsioDotNet/Events/Events.cs
+++ b/SeatsioDotNet/Events/Events.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Threading.Tasks;
 using RestSharp;
 using SeatsioDotNet.EventReports;
 using SeatsioDotNet.Util;
@@ -19,12 +20,12 @@ public class Events
         Channels = new Channels(restClient);
     }
 
-    public Event Create(string chartKey)
+    public async Task<Event> CreateAsync(string chartKey)
     {
-        return Create(chartKey, new CreateEventParams());
+        return await CreateAsync(chartKey, new CreateEventParams());
     }
 
-    public Event Create(string chartKey, CreateEventParams p)
+    public async Task<Event> CreateAsync(string chartKey, CreateEventParams p)
     {
         var requestBody = new Dictionary<string, object>();
         requestBody.Add("chartKey", chartKey);
@@ -70,10 +71,10 @@ public class Events
         }
 
         var restRequest = new RestRequest("/events", Method.Post).AddJsonBody(requestBody);
-        return AssertOk(_restClient.Execute<Event>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Event>(restRequest));
     }
 
-    public Event[] Create(string chartKey, CreateEventParams[] eventCreationParams)
+    public async Task<Event[]> CreateAsync(string chartKey, CreateEventParams[] eventCreationParams)
     {
         Dictionary<string, object> requestBody = new Dictionary<string, object>();
         requestBody.Add("chartKey", chartKey);
@@ -126,10 +127,10 @@ public class Events
 
         requestBody.Add("events", events.ToArray());
         var restRequest = new RestRequest("/events/actions/create-multiple", Method.Post).AddJsonBody(requestBody);
-        return AssertOk(_restClient.Execute<MultipleEvents>(restRequest)).events.ToArray();
+        return AssertOk(await _restClient.ExecuteAsync<MultipleEvents>(restRequest)).events.ToArray();
     }
 
-    public void Update(string eventKey, UpdateEventParams p)
+    public async Task UpdateAsync(string eventKey, UpdateEventParams p)
     {
         Dictionary<string, object> requestBody = new Dictionary<string, object>();
 
@@ -176,30 +177,30 @@ public class Events
         var restRequest = new RestRequest("/events/{key}", Method.Post)
             .AddUrlSegment("key", eventKey)
             .AddJsonBody(requestBody);
-        AssertOk(_restClient.Execute<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
     }
 
-    public void Delete(string eventKey)
+    public async Task DeleteAsync(string eventKey)
     {
         var restRequest = new RestRequest("/events/{key}", Method.Delete)
             .AddUrlSegment("key", eventKey);
-        AssertOk(_restClient.Execute<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
     }
 
-    public Event Retrieve(string eventKey)
+    public async Task<Event> RetrieveAsync(string eventKey)
     {
         var restRequest = new RestRequest("/events/{key}")
             .AddUrlSegment("key", eventKey);
-        return AssertOk(_restClient.Execute<Event>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Event>(restRequest));
     }
 
-    public EventObjectInfo RetrieveObjectInfo(string eventKey, string objectLabel)
+    public async Task<EventObjectInfo> RetrieveObjectInfoAsync(string eventKey, string objectLabel)
     {
-        var result = RetrieveObjectInfos(eventKey, new[] {objectLabel});
+        var result = await RetrieveObjectInfosAsync(eventKey, new[] {objectLabel});
         return result[objectLabel];
     }
 
-    public Dictionary<string, EventObjectInfo> RetrieveObjectInfos(string eventKey, string[] objectLabels)
+    public async Task<Dictionary<string, EventObjectInfo>> RetrieveObjectInfosAsync(string eventKey, string[] objectLabels)
     {
         var restRequest = new RestRequest("/events/{key}/objects")
             .AddUrlSegment("key", eventKey);
@@ -209,140 +210,140 @@ public class Events
             restRequest.AddQueryParameter("label", objectLabel);
         }
 
-        return AssertOk(_restClient.Execute<Dictionary<string, EventObjectInfo>>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Dictionary<string, EventObjectInfo>>(restRequest));
     }
 
-    public ChangeObjectStatusResult Book(string eventKey, IEnumerable<string> objects, string holdToken = null,
+    public async Task<ChangeObjectStatusResult> BookAsync(string eventKey, IEnumerable<string> objects, string holdToken = null,
         string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null)
     {
-        return ChangeObjectStatus(eventKey, objects, EventObjectInfo.Booked, holdToken, orderId, keepExtraData,
+        return await ChangeObjectStatusAsync(eventKey, objects, EventObjectInfo.Booked, holdToken, orderId, keepExtraData,
             ignoreChannels, channelKeys);
     }
 
-    public ChangeObjectStatusResult Book(string[] eventKeys, IEnumerable<string> objects, string holdToken = null,
+    public async Task<ChangeObjectStatusResult> BookAsync(string[] eventKeys, IEnumerable<string> objects, string holdToken = null,
         string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null)
     {
-        return ChangeObjectStatus(eventKeys, objects, EventObjectInfo.Booked, holdToken, orderId, keepExtraData,
+        return await ChangeObjectStatusAsync(eventKeys, objects, EventObjectInfo.Booked, holdToken, orderId, keepExtraData,
             ignoreChannels, channelKeys);
     }
 
-    public ChangeObjectStatusResult Book(string eventKey, IEnumerable<ObjectProperties> objects,
+    public async Task<ChangeObjectStatusResult> BookAsync(string eventKey, IEnumerable<ObjectProperties> objects,
         string holdToken = null, string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null,
         string[] channelKeys = null)
     {
-        return ChangeObjectStatus(eventKey, objects, EventObjectInfo.Booked, holdToken, orderId, keepExtraData,
+        return await ChangeObjectStatusAsync(eventKey, objects, EventObjectInfo.Booked, holdToken, orderId, keepExtraData,
             ignoreChannels, channelKeys);
     }
 
-    public ChangeObjectStatusResult Book(string[] eventKeys, IEnumerable<ObjectProperties> objects,
+    public async Task<ChangeObjectStatusResult> BookAsync(string[] eventKeys, IEnumerable<ObjectProperties> objects,
         string holdToken = null, string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null,
         string[] channelKeys = null)
     {
-        return ChangeObjectStatus(eventKeys, objects, EventObjectInfo.Booked, holdToken, orderId, keepExtraData,
+        return await ChangeObjectStatusAsync(eventKeys, objects, EventObjectInfo.Booked, holdToken, orderId, keepExtraData,
             ignoreChannels, channelKeys);
     }
 
-    public BestAvailableResult Book(string eventKey, BestAvailable bestAvailable, string holdToken = null,
+    public async Task<BestAvailableResult> BookAsync(string eventKey, BestAvailable bestAvailable, string holdToken = null,
         string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null)
     {
-        return ChangeObjectStatus(eventKey, bestAvailable, EventObjectInfo.Booked, holdToken, orderId,
+        return await ChangeObjectStatusAsync(eventKey, bestAvailable, EventObjectInfo.Booked, holdToken, orderId,
             keepExtraData, ignoreChannels, channelKeys);
     }
 
-    public ChangeObjectStatusResult Release(string eventKey, IEnumerable<string> objects, string holdToken = null,
+    public async Task<ChangeObjectStatusResult> ReleaseAsync(string eventKey, IEnumerable<string> objects, string holdToken = null,
         string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null)
     {
-        return ChangeObjectStatus(eventKey, objects, EventObjectInfo.Free, holdToken, orderId, keepExtraData,
+        return await ChangeObjectStatusAsync(eventKey, objects, EventObjectInfo.Free, holdToken, orderId, keepExtraData,
             ignoreChannels, channelKeys);
     }
 
-    public ChangeObjectStatusResult Release(string[] eventKeys, IEnumerable<string> objects,
+    public async Task<ChangeObjectStatusResult> ReleaseAsync(string[] eventKeys, IEnumerable<string> objects,
         string holdToken = null, string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null,
         string[] channelKeys = null)
     {
-        return ChangeObjectStatus(eventKeys, objects, EventObjectInfo.Free, holdToken, orderId, keepExtraData,
+        return await ChangeObjectStatusAsync(eventKeys, objects, EventObjectInfo.Free, holdToken, orderId, keepExtraData,
             ignoreChannels, channelKeys);
     }
 
-    public ChangeObjectStatusResult Release(string eventKey, IEnumerable<ObjectProperties> objects,
+    public async Task<ChangeObjectStatusResult> ReleaseAsync(string eventKey, IEnumerable<ObjectProperties> objects,
         string holdToken = null, string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null,
         string[] channelKeys = null)
     {
-        return ChangeObjectStatus(eventKey, objects, EventObjectInfo.Free, holdToken, orderId, keepExtraData,
+        return await ChangeObjectStatusAsync(eventKey, objects, EventObjectInfo.Free, holdToken, orderId, keepExtraData,
             ignoreChannels, channelKeys);
     }
 
-    public ChangeObjectStatusResult Release(string[] eventKeys, IEnumerable<ObjectProperties> objects,
+    public async Task<ChangeObjectStatusResult> ReleaseAsync(string[] eventKeys, IEnumerable<ObjectProperties> objects,
         string holdToken = null, string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null,
         string[] channelKeys = null)
     {
-        return ChangeObjectStatus(eventKeys, objects, EventObjectInfo.Free, holdToken, orderId, keepExtraData,
+        return await ChangeObjectStatusAsync(eventKeys, objects, EventObjectInfo.Free, holdToken, orderId, keepExtraData,
             ignoreChannels, channelKeys);
     }
 
-    public ChangeObjectStatusResult Hold(string eventKey, IEnumerable<string> objects, string holdToken,
+    public async Task<ChangeObjectStatusResult> HoldAsync(string eventKey, IEnumerable<string> objects, string holdToken,
         string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null)
     {
-        return ChangeObjectStatus(eventKey, objects, EventObjectInfo.Held, holdToken, orderId, keepExtraData,
+        return await ChangeObjectStatusAsync(eventKey, objects, EventObjectInfo.Held, holdToken, orderId, keepExtraData,
             ignoreChannels, channelKeys);
     }
 
-    public ChangeObjectStatusResult Hold(string[] eventKeys, IEnumerable<string> objects, string holdToken,
+    public async Task<ChangeObjectStatusResult> HoldAsync(string[] eventKeys, IEnumerable<string> objects, string holdToken,
         string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null)
     {
-        return ChangeObjectStatus(eventKeys, objects, EventObjectInfo.Held, holdToken, orderId, keepExtraData,
+        return await ChangeObjectStatusAsync(eventKeys, objects, EventObjectInfo.Held, holdToken, orderId, keepExtraData,
             ignoreChannels, channelKeys);
     }
 
-    public ChangeObjectStatusResult Hold(string eventKey, IEnumerable<ObjectProperties> objects, string holdToken,
+    public async Task<ChangeObjectStatusResult> HoldAsync(string eventKey, IEnumerable<ObjectProperties> objects, string holdToken,
         string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null)
     {
-        return ChangeObjectStatus(eventKey, objects, EventObjectInfo.Held, holdToken, orderId, keepExtraData,
+        return await ChangeObjectStatusAsync(eventKey, objects, EventObjectInfo.Held, holdToken, orderId, keepExtraData,
             ignoreChannels, channelKeys);
     }
 
-    public ChangeObjectStatusResult Hold(string[] eventKeys, IEnumerable<ObjectProperties> objects,
+    public async Task<ChangeObjectStatusResult> HoldAsync(string[] eventKeys, IEnumerable<ObjectProperties> objects,
         string holdToken, string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null,
         string[] channelKeys = null)
     {
-        return ChangeObjectStatus(eventKeys, objects, EventObjectInfo.Held, holdToken, orderId, keepExtraData,
+        return await ChangeObjectStatusAsync(eventKeys, objects, EventObjectInfo.Held, holdToken, orderId, keepExtraData,
             ignoreChannels, channelKeys);
     }
 
-    public BestAvailableResult Hold(string eventKey, BestAvailable bestAvailable, string holdToken,
+    public async Task<BestAvailableResult> HoldAsync(string eventKey, BestAvailable bestAvailable, string holdToken,
         string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null)
     {
-        return ChangeObjectStatus(eventKey, bestAvailable, EventObjectInfo.Held, holdToken, orderId, keepExtraData,
+        return await ChangeObjectStatusAsync(eventKey, bestAvailable, EventObjectInfo.Held, holdToken, orderId, keepExtraData,
             ignoreChannels, channelKeys);
     }
 
-    public ChangeObjectStatusResult ChangeObjectStatus(string eventKey, IEnumerable<string> objects, string status,
+    public async Task<ChangeObjectStatusResult> ChangeObjectStatusAsync(string eventKey, IEnumerable<string> objects, string status,
         string holdToken = null, string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null,
         string[] channelKeys = null, string[] allowedPreviousStatuses = null,
         string[] rejectedPreviousStatuses = null)
     {
-        return ChangeObjectStatus(new[] {eventKey}, objects.Select(o => new ObjectProperties(o)), status, holdToken,
+        return await ChangeObjectStatusAsync(new[] {eventKey}, objects.Select(o => new ObjectProperties(o)), status, holdToken,
             orderId, keepExtraData, ignoreChannels, channelKeys, allowedPreviousStatuses,
             rejectedPreviousStatuses);
     }
 
-    public ChangeObjectStatusResult ChangeObjectStatus(string eventKey, IEnumerable<ObjectProperties> objects,
+    public async Task<ChangeObjectStatusResult> ChangeObjectStatusAsync(string eventKey, IEnumerable<ObjectProperties> objects,
         string status, string holdToken = null, string orderId = null, bool? keepExtraData = null,
         bool? ignoreChannels = null, string[] channelKeys = null)
     {
-        return ChangeObjectStatus(new[] {eventKey}, objects, status, holdToken, orderId, keepExtraData,
+        return await ChangeObjectStatusAsync(new[] {eventKey}, objects, status, holdToken, orderId, keepExtraData,
             ignoreChannels, channelKeys);
     }
 
-    public ChangeObjectStatusResult ChangeObjectStatus(IEnumerable<string> events, IEnumerable<string> objects,
+    public async Task<ChangeObjectStatusResult> ChangeObjectStatusAsync(IEnumerable<string> events, IEnumerable<string> objects,
         string status, string holdToken = null, string orderId = null, bool? keepExtraData = null,
         bool? ignoreChannels = null, string[] channelKeys = null)
     {
-        return ChangeObjectStatus(events, objects.Select(o => new ObjectProperties(o)), status, holdToken, orderId,
+        return await ChangeObjectStatusAsync(events, objects.Select(o => new ObjectProperties(o)), status, holdToken, orderId,
             keepExtraData, ignoreChannels, channelKeys);
     }
 
-    public ChangeObjectStatusResult ChangeObjectStatus(IEnumerable<string> events,
+    public async Task<ChangeObjectStatusResult> ChangeObjectStatusAsync(IEnumerable<string> events,
         IEnumerable<ObjectProperties> objects, string status, string holdToken = null, string orderId = null,
         bool? keepExtraData = null, bool? ignoreChannels = null, string[] channelKeys = null,
         string[] allowedPreviousStatuses = null,
@@ -353,10 +354,10 @@ public class Events
         var restRequest = new RestRequest("/events/groups/actions/change-object-status", Method.Post)
             .AddQueryParameter("expand", "objects")
             .AddJsonBody(requestBody);
-        return AssertOk(_restClient.Execute<ChangeObjectStatusResult>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<ChangeObjectStatusResult>(restRequest));
     }
 
-    public List<ChangeObjectStatusResult> ChangeObjectStatus(StatusChangeRequest[] requests)
+    public async Task<List<ChangeObjectStatusResult>> ChangeObjectStatusAsync(StatusChangeRequest[] requests)
     {
         var serializedRequests = requests.Select(r => ChangeObjectStatusRequest(r.EventKey, r.Objects, r.Status,
             r.HoldToken, r.OrderId, r.KeepExtraData, r.IgnoreChannels, r.ChannelKeys,
@@ -364,7 +365,7 @@ public class Events
         var restRequest = new RestRequest("/events/actions/change-object-status", Method.Post)
             .AddQueryParameter("expand", "objects")
             .AddJsonBody(new Dictionary<string, object> {{"statusChanges", serializedRequests}});
-        return AssertOk(_restClient.Execute<ChangeObjectStatusInBatchResult>(restRequest)).Results;
+        return AssertOk(await _restClient.ExecuteAsync<ChangeObjectStatusInBatchResult>(restRequest)).Results;
     }
 
     private Dictionary<string, object> ChangeObjectStatusRequest(string evnt, IEnumerable<ObjectProperties> objects,
@@ -438,7 +439,7 @@ public class Events
         return requestBody;
     }
 
-    public BestAvailableResult ChangeObjectStatus(string eventKey, BestAvailable bestAvailable, string status,
+    public async Task<BestAvailableResult> ChangeObjectStatusAsync(string eventKey, BestAvailable bestAvailable, string status,
         string holdToken = null, string orderId = null, bool? keepExtraData = null, bool? ignoreChannels = null,
         string[] channelKeys = null)
     {
@@ -476,68 +477,68 @@ public class Events
         var restRequest = new RestRequest("/events/{key}/actions/change-object-status", Method.Post)
             .AddUrlSegment("key", eventKey)
             .AddJsonBody(requestBody);
-        return AssertOk(_restClient.Execute<BestAvailableResult>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<BestAvailableResult>(restRequest));
     }
 
-    public void OverrideSeasonObjectStatus(string eventKey, string[] objects)
+    public async Task OverrideSeasonObjectStatusAsync(string eventKey, string[] objects)
     {
         var restRequest = new RestRequest("/events/{key}/actions/override-season-status", Method.Post)
             .AddUrlSegment("key", eventKey)
             .AddJsonBody(new {objects});
-        AssertOk(_restClient.Execute<BestAvailableResult>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<BestAvailableResult>(restRequest));
     }  
     
-    public void UseSeasonObjectStatus(string eventKey, string[] objects)
+    public async Task UseSeasonObjectStatusAsync(string eventKey, string[] objects)
     {
         var restRequest = new RestRequest("/events/{key}/actions/use-season-status", Method.Post)
             .AddUrlSegment("key", eventKey)
             .AddJsonBody(new {objects});
-        AssertOk(_restClient.Execute<BestAvailableResult>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<BestAvailableResult>(restRequest));
     }
 
-    public void UpdateExtraData(string eventKey, string objectLabel, Dictionary<string, object> extraData)
+    public async Task UpdateExtraDataAsync(string eventKey, string objectLabel, Dictionary<string, object> extraData)
     {
         var restRequest = new RestRequest("/events/{key}/objects/{object}/actions/update-extra-data", Method.Post)
             .AddUrlSegment("key", eventKey)
             .AddUrlSegment("object", objectLabel)
             .AddJsonBody(new {extraData});
-        AssertOk(_restClient.Execute<BestAvailableResult>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<BestAvailableResult>(restRequest));
     }
 
-    public void UpdateExtraDatas(string eventKey, Dictionary<string, Dictionary<string, object>> extraData)
+    public async Task UpdateExtraDatasAsync(string eventKey, Dictionary<string, Dictionary<string, object>> extraData)
     {
         var restRequest = new RestRequest("/events/{key}/actions/update-extra-data", Method.Post)
             .AddUrlSegment("key", eventKey)
             .AddParameter("application/json", JsonSerializer.Serialize(new {extraData}),
                 ParameterType.RequestBody); // default serializer doesn't convert extraData to JSON properly
-        AssertOk(_restClient.Execute<BestAvailableResult>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<BestAvailableResult>(restRequest));
     }
 
-    public void MarkAsForSale(string eventKey, IEnumerable<string> objects, Dictionary<string, int> areaPlaces,
+    public async Task MarkAsForSaleAsync(string eventKey, IEnumerable<string> objects, Dictionary<string, int> areaPlaces,
         IEnumerable<string> categories)
     {
         var requestBody = ForSaleRequest(objects, areaPlaces, categories);
         var restRequest = new RestRequest("/events/{key}/actions/mark-as-for-sale", Method.Post)
             .AddUrlSegment("key", eventKey)
             .AddJsonBody(requestBody);
-        AssertOk(_restClient.Execute<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
     }
 
-    public void MarkAsNotForSale(string eventKey, IEnumerable<string> objects, Dictionary<string, int> areaPlaces,
+    public async Task MarkAsNotForSaleAsync(string eventKey, IEnumerable<string> objects, Dictionary<string, int> areaPlaces,
         IEnumerable<string> categories)
     {
         var requestBody = ForSaleRequest(objects, areaPlaces, categories);
         var restRequest = new RestRequest("/events/{key}/actions/mark-as-not-for-sale", Method.Post)
             .AddUrlSegment("key", eventKey)
             .AddJsonBody(requestBody);
-        AssertOk(_restClient.Execute<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
     }
 
-    public void MarkEverythingAsForSale(string eventKey)
+    public async Task MarkEverythingAsForSaleAsync(string eventKey)
     {
         var restRequest = new RestRequest("/events/{key}/actions/mark-everything-as-for-sale", Method.Post)
             .AddUrlSegment("key", eventKey);
-        AssertOk(_restClient.Execute<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
     }
 
     private Dictionary<string, object> ForSaleRequest(IEnumerable<string> objects,
@@ -563,24 +564,24 @@ public class Events
         return request;
     }
 
-    public IEnumerable<Event> ListAll()
+    public IAsyncEnumerable<Event> ListAllAsync()
     {
-        return List().All();
+        return List().AllAsync();
     }
 
-    public Page<Event> ListFirstPage(int? pageSize = null)
+    public async Task<Page<Event>> ListFirstPageAsync(int? pageSize = null)
     {
-        return List().FirstPage(pageSize: pageSize);
+        return await List().FirstPageAsync(pageSize: pageSize);
     }
 
-    public Page<Event> ListPageAfter(long id, int? pageSize = null)
+    public async Task<Page<Event>> ListPageAfterAsync(long id, int? pageSize = null)
     {
-        return List().PageAfter(id, pageSize: pageSize);
+        return await List().PageAfterAsync(id, pageSize: pageSize);
     }
 
-    public Page<Event> ListPageBefore(long id, int? pageSize = null)
+    public async Task<Page<Event>> ListPageBeforeAsync(long id, int? pageSize = null)
     {
-        return List().PageBefore(id, pageSize: pageSize);
+        return await List().PageBeforeAsync(id, pageSize: pageSize);
     }
 
     private Lister<Event> List()

--- a/SeatsioDotNet/HoldTokens/HoldTokens.cs
+++ b/SeatsioDotNet/HoldTokens/HoldTokens.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using RestSharp;
 using static SeatsioDotNet.Util.RestUtil;
 
@@ -13,31 +14,31 @@ public class HoldTokens
         _restClient = restClient;
     }
 
-    public async Task<HoldToken> CreateAsync()
+    public async Task<HoldToken> CreateAsync(CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/hold-tokens", Method.Post);
-        return AssertOk(await _restClient.ExecuteAsync<HoldToken>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<HoldToken>(restRequest, cancellationToken));
     }
 
-    public async Task<HoldToken> CreateAsync(int expiresInMinutes)
+    public async Task<HoldToken> CreateAsync(int expiresInMinutes, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/hold-tokens", Method.Post)
             .AddJsonBody(new {expiresInMinutes});
-        return AssertOk(await _restClient.ExecuteAsync<HoldToken>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<HoldToken>(restRequest, cancellationToken));
     }
 
-    public async Task<HoldToken> ExpiresInMinutesAsync(string token, int expiresInMinutes)
+    public async Task<HoldToken> ExpiresInMinutesAsync(string token, int expiresInMinutes, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/hold-tokens/{token}", Method.Post)
             .AddUrlSegment("token", token)
             .AddJsonBody(new {expiresInMinutes});
-        return AssertOk(await _restClient.ExecuteAsync<HoldToken>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<HoldToken>(restRequest, cancellationToken));
     }
 
-    public async Task<HoldToken> RetrieveAsync(string token)
+    public async Task<HoldToken> RetrieveAsync(string token, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/hold-tokens/{token}", Method.Get)
             .AddUrlSegment("token", token);
-        return AssertOk(await _restClient.ExecuteAsync<HoldToken>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<HoldToken>(restRequest, cancellationToken));
     }
 }

--- a/SeatsioDotNet/HoldTokens/HoldTokens.cs
+++ b/SeatsioDotNet/HoldTokens/HoldTokens.cs
@@ -1,4 +1,5 @@
-﻿using RestSharp;
+﻿using System.Threading.Tasks;
+using RestSharp;
 using static SeatsioDotNet.Util.RestUtil;
 
 namespace SeatsioDotNet.HoldTokens;
@@ -12,31 +13,31 @@ public class HoldTokens
         _restClient = restClient;
     }
 
-    public HoldToken Create()
+    public async Task<HoldToken> CreateAsync()
     {
         var restRequest = new RestRequest("/hold-tokens", Method.Post);
-        return AssertOk(_restClient.Execute<HoldToken>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<HoldToken>(restRequest));
     }
 
-    public HoldToken Create(int expiresInMinutes)
+    public async Task<HoldToken> CreateAsync(int expiresInMinutes)
     {
         var restRequest = new RestRequest("/hold-tokens", Method.Post)
             .AddJsonBody(new {expiresInMinutes});
-        return AssertOk(_restClient.Execute<HoldToken>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<HoldToken>(restRequest));
     }
 
-    public HoldToken ExpiresInMinutes(string token, int expiresInMinutes)
+    public async Task<HoldToken> ExpiresInMinutesAsync(string token, int expiresInMinutes)
     {
         var restRequest = new RestRequest("/hold-tokens/{token}", Method.Post)
             .AddUrlSegment("token", token)
             .AddJsonBody(new {expiresInMinutes});
-        return AssertOk(_restClient.Execute<HoldToken>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<HoldToken>(restRequest));
     }
 
-    public HoldToken Retrieve(string token)
+    public async Task<HoldToken> RetrieveAsync(string token)
     {
         var restRequest = new RestRequest("/hold-tokens/{token}", Method.Get)
             .AddUrlSegment("token", token);
-        return AssertOk(_restClient.Execute<HoldToken>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<HoldToken>(restRequest));
     }
 }

--- a/SeatsioDotNet/Reports/Charts/ChartReports.cs
+++ b/SeatsioDotNet/Reports/Charts/ChartReports.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using RestSharp;
 using SeatsioDotNet.ChartReports;
 using static SeatsioDotNet.Util.RestUtil;
@@ -20,52 +21,52 @@ public class ChartReports
         _restClient = restClient;
     }
 
-    public Dictionary<string, IEnumerable<ChartObjectInfo>> ByLabel(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
+    public async Task<Dictionary<string, IEnumerable<ChartObjectInfo>>> ByLabelAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
     {
-        return FetchReport("byLabel", chartKey, bookWholeTablesMode, version);
+        return await FetchReportAsync("byLabel", chartKey, bookWholeTablesMode, version);
     }    
         
-    public Dictionary<string, IEnumerable<ChartObjectInfo>> ByObjectType(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
+    public async Task<Dictionary<string, IEnumerable<ChartObjectInfo>>> ByObjectTypeAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
     {
-        return FetchReport("byObjectType", chartKey, bookWholeTablesMode, version);
+        return await FetchReportAsync("byObjectType", chartKey, bookWholeTablesMode, version);
     }
         
-    public Dictionary<string, ChartReportSummaryItem> SummaryByObjectType(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
+    public async Task<Dictionary<string, ChartReportSummaryItem>> SummaryByObjectTypeAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
     {
-        return FetchSummaryReport("byObjectType", chartKey, bookWholeTablesMode, version);
+        return await FetchSummaryReportAsync("byObjectType", chartKey, bookWholeTablesMode, version);
     }
         
-    public Dictionary<string, IEnumerable<ChartObjectInfo>> ByCategoryKey(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
+    public async Task<Dictionary<string, IEnumerable<ChartObjectInfo>>> ByCategoryKeyAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
     {
-        return FetchReport("byCategoryKey", chartKey, bookWholeTablesMode, version);
+        return await FetchReportAsync("byCategoryKey", chartKey, bookWholeTablesMode, version);
     }
         
-    public Dictionary<string, ChartReportSummaryItem> SummaryByCategoryKey(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
+    public async Task<Dictionary<string, ChartReportSummaryItem>> SummaryByCategoryKeyAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
     {
-        return FetchSummaryReport("byCategoryKey", chartKey, bookWholeTablesMode, version);
+        return await FetchSummaryReportAsync("byCategoryKey", chartKey, bookWholeTablesMode, version);
     }
         
-    public Dictionary<string, IEnumerable<ChartObjectInfo>> ByCategoryLabel(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
+    public async Task<Dictionary<string, IEnumerable<ChartObjectInfo>>> ByCategoryLabelAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
     {
-        return FetchReport("byCategoryLabel", chartKey, bookWholeTablesMode, version);
+        return await FetchReportAsync("byCategoryLabel", chartKey, bookWholeTablesMode, version);
     }   
         
-    public Dictionary<string, ChartReportSummaryItem> SummaryByCategoryLabel(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
+    public async Task<Dictionary<string, ChartReportSummaryItem>> SummaryByCategoryLabelAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
     {
-        return FetchSummaryReport("byCategoryLabel", chartKey, bookWholeTablesMode, version);
+        return await FetchSummaryReportAsync("byCategoryLabel", chartKey, bookWholeTablesMode, version);
     }
         
-    public Dictionary<string, IEnumerable<ChartObjectInfo>> BySection(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
+    public async Task<Dictionary<string, IEnumerable<ChartObjectInfo>>> BySectionAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
     {
-        return FetchReport("bySection", chartKey, bookWholeTablesMode, version);
+        return await FetchReportAsync("bySection", chartKey, bookWholeTablesMode, version);
     }
         
-    public Dictionary<string, ChartReportSummaryItem> SummaryBySection(string eventKey, string bookWholeTablesMode = null, Version version = Version.Production)
+    public async Task<Dictionary<string, ChartReportSummaryItem>> SummaryBySectionAsync(string eventKey, string bookWholeTablesMode = null, Version version = Version.Production)
     {
-        return FetchSummaryReport("bySection", eventKey, bookWholeTablesMode, version);
+        return await FetchSummaryReportAsync("bySection", eventKey, bookWholeTablesMode, version);
     }
 
-    private Dictionary<string, IEnumerable<ChartObjectInfo>> FetchReport(string reportType, string chartKey, string bookWholeTablesMode, Version version = Version.Production)
+    private async Task<Dictionary<string, IEnumerable<ChartObjectInfo>>> FetchReportAsync(string reportType, string chartKey, string bookWholeTablesMode, Version version = Version.Production)
     {
         var restRequest = new RestRequest("/reports/charts/{key}/{reportType}", Method.Get)
             .AddUrlSegment("key", chartKey)
@@ -80,10 +81,10 @@ public class ChartReports
             restRequest.AddQueryParameter("version", version.ToString());
         }
             
-        return AssertOk(_restClient.Execute<Dictionary<string, IEnumerable<ChartObjectInfo>>>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Dictionary<string, IEnumerable<ChartObjectInfo>>>(restRequest));
     }
         
-    private Dictionary<string, ChartReportSummaryItem> FetchSummaryReport(string reportType, string chartKey, string bookWholeTablesMode, Version version = Version.Production)
+    private async Task<Dictionary<string, ChartReportSummaryItem>> FetchSummaryReportAsync(string reportType, string chartKey, string bookWholeTablesMode, Version version = Version.Production)
     {
         var restRequest = new RestRequest("/reports/charts/{key}/{reportType}/summary", Method.Get)
             .AddUrlSegment("key", chartKey)
@@ -98,6 +99,6 @@ public class ChartReports
             restRequest.AddQueryParameter("version", version.ToString());
         }
             
-        return AssertOk(_restClient.Execute<Dictionary<string, ChartReportSummaryItem>>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Dictionary<string, ChartReportSummaryItem>>(restRequest));
     }
 }

--- a/SeatsioDotNet/Reports/Charts/ChartReports.cs
+++ b/SeatsioDotNet/Reports/Charts/ChartReports.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using RestSharp;
 using SeatsioDotNet.ChartReports;
@@ -21,52 +22,52 @@ public class ChartReports
         _restClient = restClient;
     }
 
-    public async Task<Dictionary<string, IEnumerable<ChartObjectInfo>>> ByLabelAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
+    public async Task<Dictionary<string, IEnumerable<ChartObjectInfo>>> ByLabelAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production, CancellationToken cancellationToken = default)
     {
-        return await FetchReportAsync("byLabel", chartKey, bookWholeTablesMode, version);
+        return await FetchReportAsync("byLabel", chartKey, bookWholeTablesMode, version, cancellationToken);
     }    
         
-    public async Task<Dictionary<string, IEnumerable<ChartObjectInfo>>> ByObjectTypeAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
+    public async Task<Dictionary<string, IEnumerable<ChartObjectInfo>>> ByObjectTypeAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production, CancellationToken cancellationToken = default)
     {
-        return await FetchReportAsync("byObjectType", chartKey, bookWholeTablesMode, version);
+        return await FetchReportAsync("byObjectType", chartKey, bookWholeTablesMode, version, cancellationToken);
     }
         
-    public async Task<Dictionary<string, ChartReportSummaryItem>> SummaryByObjectTypeAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
+    public async Task<Dictionary<string, ChartReportSummaryItem>> SummaryByObjectTypeAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production, CancellationToken cancellationToken = default)
     {
-        return await FetchSummaryReportAsync("byObjectType", chartKey, bookWholeTablesMode, version);
+        return await FetchSummaryReportAsync("byObjectType", chartKey, bookWholeTablesMode, version, cancellationToken);
     }
         
-    public async Task<Dictionary<string, IEnumerable<ChartObjectInfo>>> ByCategoryKeyAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
+    public async Task<Dictionary<string, IEnumerable<ChartObjectInfo>>> ByCategoryKeyAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production, CancellationToken cancellationToken = default)
     {
-        return await FetchReportAsync("byCategoryKey", chartKey, bookWholeTablesMode, version);
+        return await FetchReportAsync("byCategoryKey", chartKey, bookWholeTablesMode, version, cancellationToken);
     }
         
-    public async Task<Dictionary<string, ChartReportSummaryItem>> SummaryByCategoryKeyAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
+    public async Task<Dictionary<string, ChartReportSummaryItem>> SummaryByCategoryKeyAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production, CancellationToken cancellationToken = default)
     {
-        return await FetchSummaryReportAsync("byCategoryKey", chartKey, bookWholeTablesMode, version);
+        return await FetchSummaryReportAsync("byCategoryKey", chartKey, bookWholeTablesMode, version, cancellationToken);
     }
         
-    public async Task<Dictionary<string, IEnumerable<ChartObjectInfo>>> ByCategoryLabelAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
+    public async Task<Dictionary<string, IEnumerable<ChartObjectInfo>>> ByCategoryLabelAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production, CancellationToken cancellationToken = default)
     {
-        return await FetchReportAsync("byCategoryLabel", chartKey, bookWholeTablesMode, version);
+        return await FetchReportAsync("byCategoryLabel", chartKey, bookWholeTablesMode, version, cancellationToken);
     }   
         
-    public async Task<Dictionary<string, ChartReportSummaryItem>> SummaryByCategoryLabelAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
+    public async Task<Dictionary<string, ChartReportSummaryItem>> SummaryByCategoryLabelAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production, CancellationToken cancellationToken = default)
     {
-        return await FetchSummaryReportAsync("byCategoryLabel", chartKey, bookWholeTablesMode, version);
+        return await FetchSummaryReportAsync("byCategoryLabel", chartKey, bookWholeTablesMode, version, cancellationToken);
     }
         
-    public async Task<Dictionary<string, IEnumerable<ChartObjectInfo>>> BySectionAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production)
+    public async Task<Dictionary<string, IEnumerable<ChartObjectInfo>>> BySectionAsync(string chartKey, string bookWholeTablesMode = null, Version version = Version.Production, CancellationToken cancellationToken = default)
     {
-        return await FetchReportAsync("bySection", chartKey, bookWholeTablesMode, version);
+        return await FetchReportAsync("bySection", chartKey, bookWholeTablesMode, version, cancellationToken);
     }
         
-    public async Task<Dictionary<string, ChartReportSummaryItem>> SummaryBySectionAsync(string eventKey, string bookWholeTablesMode = null, Version version = Version.Production)
+    public async Task<Dictionary<string, ChartReportSummaryItem>> SummaryBySectionAsync(string eventKey, string bookWholeTablesMode = null, Version version = Version.Production, CancellationToken cancellationToken = default)
     {
-        return await FetchSummaryReportAsync("bySection", eventKey, bookWholeTablesMode, version);
+        return await FetchSummaryReportAsync("bySection", eventKey, bookWholeTablesMode, version, cancellationToken);
     }
 
-    private async Task<Dictionary<string, IEnumerable<ChartObjectInfo>>> FetchReportAsync(string reportType, string chartKey, string bookWholeTablesMode, Version version = Version.Production)
+    private async Task<Dictionary<string, IEnumerable<ChartObjectInfo>>> FetchReportAsync(string reportType, string chartKey, string bookWholeTablesMode, Version version = Version.Production, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/reports/charts/{key}/{reportType}", Method.Get)
             .AddUrlSegment("key", chartKey)
@@ -81,10 +82,10 @@ public class ChartReports
             restRequest.AddQueryParameter("version", version.ToString());
         }
             
-        return AssertOk(await _restClient.ExecuteAsync<Dictionary<string, IEnumerable<ChartObjectInfo>>>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Dictionary<string, IEnumerable<ChartObjectInfo>>>(restRequest, cancellationToken));
     }
         
-    private async Task<Dictionary<string, ChartReportSummaryItem>> FetchSummaryReportAsync(string reportType, string chartKey, string bookWholeTablesMode, Version version = Version.Production)
+    private async Task<Dictionary<string, ChartReportSummaryItem>> FetchSummaryReportAsync(string reportType, string chartKey, string bookWholeTablesMode, Version version = Version.Production, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/reports/charts/{key}/{reportType}/summary", Method.Get)
             .AddUrlSegment("key", chartKey)
@@ -99,6 +100,6 @@ public class ChartReports
             restRequest.AddQueryParameter("version", version.ToString());
         }
             
-        return AssertOk(await _restClient.ExecuteAsync<Dictionary<string, ChartReportSummaryItem>>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Dictionary<string, ChartReportSummaryItem>>(restRequest, cancellationToken));
     }
 }

--- a/SeatsioDotNet/Reports/Events/EventReports.cs
+++ b/SeatsioDotNet/Reports/Events/EventReports.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using RestSharp;
 using SeatsioDotNet.EventReports;
 using static SeatsioDotNet.Util.RestUtil;
@@ -14,218 +15,218 @@ public class EventReports
         _restClient = restClient;
     }
 
-    public Dictionary<string, IEnumerable<EventObjectInfo>> ByLabel(string eventKey)
+    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByLabelAsync(string eventKey)
     {
-        return FetchReport("byLabel", eventKey);
+        return await FetchReportAsync("byLabel", eventKey);
     }
 
-    public IEnumerable<EventObjectInfo> ByLabel(string eventKey, string label)
+    public async Task<IEnumerable<EventObjectInfo>> ByLabelAsync(string eventKey, string label)
     {
-        return FetchReport("byLabel", eventKey, label);
+        return await FetchReport("byLabel", eventKey, label);
     }
 
-    public Dictionary<string, IEnumerable<EventObjectInfo>> ByStatus(string eventKey)
+    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByStatusAsync(string eventKey)
     {
-        return FetchReport("byStatus", eventKey);
+        return await FetchReportAsync("byStatus", eventKey);
     }
 
-    public Dictionary<string, EventReportSummaryItem> SummaryByStatus(string eventKey)
+    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryByStatusAsync(string eventKey)
     {
-        return FetchSummaryReport("byStatus", eventKey);
+        return await FetchSummaryReport("byStatus", eventKey);
     }
 
-    public Dictionary<string, EventReportDeepSummaryItem> DeepSummaryByStatus(string eventKey)
+    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryByStatusAsync(string eventKey)
     {
-        return FetchDeepSummaryReport("byStatus", eventKey);
+        return await FetchDeepSummaryReport("byStatus", eventKey);
     }
 
-    public IEnumerable<EventObjectInfo> ByStatus(string eventKey, string status)
+    public async Task<IEnumerable<EventObjectInfo>> ByStatusAsync(string eventKey, string status)
     {
-        return FetchReport("byStatus", eventKey, status);
+        return await FetchReport("byStatus", eventKey, status);
     }
 
-    public Dictionary<string, IEnumerable<EventObjectInfo>> ByObjectType(string eventKey)
+    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByObjectTypeAsync(string eventKey)
     {
-        return FetchReport("byObjectType", eventKey);
+        return await FetchReportAsync("byObjectType", eventKey);
     }
 
-    public Dictionary<string, EventReportSummaryItem> SummaryByObjectType(string eventKey)
+    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryByObjectTypeAsync(string eventKey)
     {
-        return FetchSummaryReport("byObjectType", eventKey);
+        return await FetchSummaryReport("byObjectType", eventKey);
     }
 
-    public Dictionary<string, EventReportDeepSummaryItem> DeepSummaryByObjectType(string eventKey)
+    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryByObjectTypeAsync(string eventKey)
     {
-        return FetchDeepSummaryReport("byObjectType", eventKey);
+        return await FetchDeepSummaryReport("byObjectType", eventKey);
     }
 
-    public IEnumerable<EventObjectInfo> ByObjectType(string eventKey, string objectType)
+    public async Task<IEnumerable<EventObjectInfo>> ByObjectTypeAsync(string eventKey, string objectType)
     {
-        return FetchReport("byObjectType", eventKey, objectType);
+        return await FetchReport("byObjectType", eventKey, objectType);
     }
 
-    public Dictionary<string, IEnumerable<EventObjectInfo>> ByCategoryLabel(string eventKey)
+    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByCategoryLabelAsync(string eventKey)
     {
-        return FetchReport("byCategoryLabel", eventKey);
+        return await FetchReportAsync("byCategoryLabel", eventKey);
     }
 
-    public Dictionary<string, EventReportSummaryItem> SummaryByCategoryLabel(string eventKey)
+    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryByCategoryLabeAsync(string eventKey)
     {
-        return FetchSummaryReport("byCategoryLabel", eventKey);
+        return await FetchSummaryReport("byCategoryLabel", eventKey);
     }
 
-    public Dictionary<string, EventReportDeepSummaryItem> DeepSummaryByCategoryLabel(string eventKey)
+    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryByCategoryLabelAsync(string eventKey)
     {
-        return FetchDeepSummaryReport("byCategoryLabel", eventKey);
+        return await FetchDeepSummaryReport("byCategoryLabel", eventKey);
     }
 
-    public IEnumerable<EventObjectInfo> ByCategoryLabel(string eventKey, string categoryLabel)
+    public async Task<IEnumerable<EventObjectInfo>> ByCategoryLabelAsync(string eventKey, string categoryLabel)
     {
-        return FetchReport("byCategoryLabel", eventKey, categoryLabel);
+        return await FetchReport("byCategoryLabel", eventKey, categoryLabel);
     }
 
-    public Dictionary<string, IEnumerable<EventObjectInfo>> ByCategoryKey(string eventKey)
+    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByCategoryKeyAsync(string eventKey)
     {
-        return FetchReport("byCategoryKey", eventKey);
+        return await FetchReportAsync("byCategoryKey", eventKey);
     }
 
-    public Dictionary<string, EventReportSummaryItem> SummaryByCategoryKey(string eventKey)
+    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryByCategoryKeyAsync(string eventKey)
     {
-        return FetchSummaryReport("byCategoryKey", eventKey);
+        return await FetchSummaryReport("byCategoryKey", eventKey);
     }
 
-    public Dictionary<string, EventReportDeepSummaryItem> DeepSummaryByCategoryKey(string eventKey)
+    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryByCategoryKeyAsync(string eventKey)
     {
-        return FetchDeepSummaryReport("byCategoryKey", eventKey);
+        return await FetchDeepSummaryReport("byCategoryKey", eventKey);
     }
 
-    public IEnumerable<EventObjectInfo> ByCategoryKey(string eventKey, string categoryKey)
+    public async Task<IEnumerable<EventObjectInfo>> ByCategoryKeyAsync(string eventKey, string categoryKey)
     {
-        return FetchReport("byCategoryKey", eventKey, categoryKey);
+        return await FetchReport("byCategoryKey", eventKey, categoryKey);
     }
 
-    public Dictionary<string, IEnumerable<EventObjectInfo>> ByOrderId(string eventKey)
+    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByOrderIdAsync(string eventKey)
     {
-        return FetchReport("byOrderId", eventKey);
+        return await FetchReportAsync("byOrderId", eventKey);
     }
 
-    public IEnumerable<EventObjectInfo> ByOrderId(string eventKey, string categoryKey)
+    public async Task<IEnumerable<EventObjectInfo>> ByOrderIdAsync(string eventKey, string categoryKey)
     {
-        return FetchReport("byOrderId", eventKey, categoryKey);
+        return await FetchReport("byOrderId", eventKey, categoryKey);
     }
 
-    public Dictionary<string, IEnumerable<EventObjectInfo>> BySection(string eventKey)
+    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> BySectionAsync(string eventKey)
     {
-        return FetchReport("bySection", eventKey);
+        return await FetchReportAsync("bySection", eventKey);
     }
 
-    public Dictionary<string, EventReportSummaryItem> SummaryBySection(string eventKey)
+    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryBySectionAsync(string eventKey)
     {
-        return FetchSummaryReport("bySection", eventKey);
+        return await FetchSummaryReport("bySection", eventKey);
     }
 
-    public Dictionary<string, EventReportDeepSummaryItem> DeepSummaryBySection(string eventKey)
+    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryBySectionAsync(string eventKey)
     {
-        return FetchDeepSummaryReport("bySection", eventKey);
+        return await FetchDeepSummaryReport("bySection", eventKey);
     }
 
-    public IEnumerable<EventObjectInfo> BySection(string eventKey, string section)
+    public async Task<IEnumerable<EventObjectInfo>> BySection(string eventKey, string section)
     {
-        return FetchReport("bySection", eventKey, section);
+        return await FetchReport("bySection", eventKey, section);
     }
 
-    public Dictionary<string, IEnumerable<EventObjectInfo>> ByAvailability(string eventKey)
+    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByAvailabilityAsync(string eventKey)
     {
-        return FetchReport("byAvailability", eventKey);
+        return await FetchReportAsync("byAvailability", eventKey);
     }
 
-    public IEnumerable<EventObjectInfo> ByAvailability(string eventKey, string availability)
+    public async Task<IEnumerable<EventObjectInfo>> ByAvailabilityAsync(string eventKey, string availability)
     {
-        return FetchReport("byAvailability", eventKey, availability);
+        return await FetchReport("byAvailability", eventKey, availability);
     }
 
-    public Dictionary<string, EventReportSummaryItem> SummaryByAvailability(string eventKey)
+    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryByAvailabilityAsync(string eventKey)
     {
-        return FetchSummaryReport("byAvailability", eventKey);
+        return await FetchSummaryReport("byAvailability", eventKey);
     }
 
-    public Dictionary<string, EventReportDeepSummaryItem> DeepSummaryByAvailability(string eventKey)
+    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryByAvailabilityAsync(string eventKey)
     {
-        return FetchDeepSummaryReport("byAvailability", eventKey);
+        return await FetchDeepSummaryReport("byAvailability", eventKey);
     }
 
-    public Dictionary<string, IEnumerable<EventObjectInfo>> ByAvailabilityReason(string eventKey)
+    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByAvailabilityReasonAsync(string eventKey)
     {
-        return FetchReport("byAvailabilityReason", eventKey);
+        return await FetchReportAsync("byAvailabilityReason", eventKey);
     }
 
-    public IEnumerable<EventObjectInfo> ByAvailabilityReason(string eventKey, string availabilityReason)
+    public async Task<IEnumerable<EventObjectInfo>> ByAvailabilityReasonAsync(string eventKey, string availabilityReason)
     {
-        return FetchReport("byAvailabilityReason", eventKey, availabilityReason);
+        return await FetchReport("byAvailabilityReason", eventKey, availabilityReason);
     }
 
-    public Dictionary<string, EventReportSummaryItem> SummaryByAvailabilityReason(string eventKey)
+    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryByAvailabilityReasonAsync(string eventKey)
     {
-        return FetchSummaryReport("byAvailabilityReason", eventKey);
+        return await FetchSummaryReport("byAvailabilityReason", eventKey);
     }
 
-    public Dictionary<string, EventReportDeepSummaryItem> DeepSummaryByAvailabilityReason(string eventKey)
+    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryByAvailabilityReasonAsync(string eventKey)
     {
-        return FetchDeepSummaryReport("byAvailabilityReason", eventKey);
+        return await FetchDeepSummaryReport("byAvailabilityReason", eventKey);
     }
 
-    public Dictionary<string, IEnumerable<EventObjectInfo>> ByChannel(string eventKey)
+    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByChannelAsync(string eventKey)
     {
-        return FetchReport("byChannel", eventKey);
+        return await FetchReportAsync("byChannel", eventKey);
     }
 
-    public Dictionary<string, EventReportSummaryItem> SummaryByChannel(string eventKey)
+    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryByChannelAsync(string eventKey)
     {
-        return FetchSummaryReport("byChannel", eventKey);
+        return await FetchSummaryReport("byChannel", eventKey);
     }
 
-    public Dictionary<string, EventReportDeepSummaryItem> DeepSummaryByChannel(string eventKey)
+    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryByChannelAsync(string eventKey)
     {
-        return FetchDeepSummaryReport("byChannel", eventKey);
+        return await FetchDeepSummaryReport("byChannel", eventKey);
     }
 
-    public IEnumerable<EventObjectInfo> ByChannel(string eventKey, string channelKey)
+    public async Task<IEnumerable<EventObjectInfo>> ByChannelAsync(string eventKey, string channelKey)
     {
-        return FetchReport("byChannel", eventKey, channelKey);
+        return await FetchReport("byChannel", eventKey, channelKey);
     }
 
-    private Dictionary<string, IEnumerable<EventObjectInfo>> FetchReport(string reportType, string eventKey)
+    private async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> FetchReportAsync(string reportType, string eventKey)
     {
         var restRequest = new RestRequest("/reports/events/{key}/{reportType}", Method.Get)
             .AddUrlSegment("key", eventKey)
             .AddUrlSegment("reportType", reportType);
-        return AssertOk(_restClient.Execute<Dictionary<string, IEnumerable<EventObjectInfo>>>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Dictionary<string, IEnumerable<EventObjectInfo>>>(restRequest));
     }
 
-    private Dictionary<string, EventReportSummaryItem> FetchSummaryReport(string reportType, string eventKey)
+    private async Task<Dictionary<string, EventReportSummaryItem>> FetchSummaryReport(string reportType, string eventKey)
     {
         var restRequest = new RestRequest("/reports/events/{key}/{reportType}/summary", Method.Get)
             .AddUrlSegment("key", eventKey)
             .AddUrlSegment("reportType", reportType);
-        return AssertOk(_restClient.Execute<Dictionary<string, EventReportSummaryItem>>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Dictionary<string, EventReportSummaryItem>>(restRequest));
     }
 
-    private Dictionary<string, EventReportDeepSummaryItem> FetchDeepSummaryReport(string reportType,
+    private async Task<Dictionary<string, EventReportDeepSummaryItem>> FetchDeepSummaryReport(string reportType,
         string eventKey)
     {
         var restRequest = new RestRequest("/reports/events/{key}/{reportType}/summary/deep", Method.Get)
             .AddUrlSegment("key", eventKey)
             .AddUrlSegment("reportType", reportType);
-        return AssertOk(_restClient.Execute<Dictionary<string, EventReportDeepSummaryItem>>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Dictionary<string, EventReportDeepSummaryItem>>(restRequest));
     }
 
-    private IEnumerable<EventObjectInfo> FetchReport(string reportType, string eventKey, string filter)
+    private async Task<IEnumerable<EventObjectInfo>> FetchReport(string reportType, string eventKey, string filter)
     {
         var restRequest = new RestRequest("/reports/events/{key}/{reportType}/{filter}", Method.Get)
             .AddUrlSegment("key", eventKey)
             .AddUrlSegment("reportType", reportType)
             .AddUrlSegment("filter", filter);
-        var report = AssertOk(_restClient.Execute<Dictionary<string, IEnumerable<EventObjectInfo>>>(restRequest));
+        var report = AssertOk(await _restClient.ExecuteAsync<Dictionary<string, IEnumerable<EventObjectInfo>>>(restRequest));
         if (report.ContainsKey(filter))
         {
             return report[filter];

--- a/SeatsioDotNet/Reports/Events/EventReports.cs
+++ b/SeatsioDotNet/Reports/Events/EventReports.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using RestSharp;
 using SeatsioDotNet.EventReports;
@@ -15,218 +16,218 @@ public class EventReports
         _restClient = restClient;
     }
 
-    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByLabelAsync(string eventKey)
+    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByLabelAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchReportAsync("byLabel", eventKey);
+        return await FetchReportAsync("byLabel", eventKey, cancellationToken);
     }
 
-    public async Task<IEnumerable<EventObjectInfo>> ByLabelAsync(string eventKey, string label)
+    public async Task<IEnumerable<EventObjectInfo>> ByLabelAsync(string eventKey, string label, CancellationToken cancellationToken = default)
     {
-        return await FetchReport("byLabel", eventKey, label);
+        return await FetchReport("byLabel", eventKey, label, cancellationToken);
     }
 
-    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByStatusAsync(string eventKey)
+    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByStatusAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchReportAsync("byStatus", eventKey);
+        return await FetchReportAsync("byStatus", eventKey, cancellationToken);
     }
 
-    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryByStatusAsync(string eventKey)
+    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryByStatusAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchSummaryReport("byStatus", eventKey);
+        return await FetchSummaryReport("byStatus", eventKey, cancellationToken);
     }
 
-    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryByStatusAsync(string eventKey)
+    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryByStatusAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchDeepSummaryReport("byStatus", eventKey);
+        return await FetchDeepSummaryReport("byStatus", eventKey, cancellationToken);
     }
 
-    public async Task<IEnumerable<EventObjectInfo>> ByStatusAsync(string eventKey, string status)
+    public async Task<IEnumerable<EventObjectInfo>> ByStatusAsync(string eventKey, string status, CancellationToken cancellationToken = default)
     {
-        return await FetchReport("byStatus", eventKey, status);
+        return await FetchReport("byStatus", eventKey, status, cancellationToken);
     }
 
-    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByObjectTypeAsync(string eventKey)
+    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByObjectTypeAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchReportAsync("byObjectType", eventKey);
+        return await FetchReportAsync("byObjectType", eventKey, cancellationToken);
     }
 
-    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryByObjectTypeAsync(string eventKey)
+    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryByObjectTypeAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchSummaryReport("byObjectType", eventKey);
+        return await FetchSummaryReport("byObjectType", eventKey, cancellationToken);
     }
 
-    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryByObjectTypeAsync(string eventKey)
+    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryByObjectTypeAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchDeepSummaryReport("byObjectType", eventKey);
+        return await FetchDeepSummaryReport("byObjectType", eventKey, cancellationToken);
     }
 
-    public async Task<IEnumerable<EventObjectInfo>> ByObjectTypeAsync(string eventKey, string objectType)
+    public async Task<IEnumerable<EventObjectInfo>> ByObjectTypeAsync(string eventKey, string objectType, CancellationToken cancellationToken = default)
     {
-        return await FetchReport("byObjectType", eventKey, objectType);
+        return await FetchReport("byObjectType", eventKey, objectType, cancellationToken);
     }
 
-    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByCategoryLabelAsync(string eventKey)
+    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByCategoryLabelAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchReportAsync("byCategoryLabel", eventKey);
+        return await FetchReportAsync("byCategoryLabel", eventKey, cancellationToken);
     }
 
-    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryByCategoryLabeAsync(string eventKey)
+    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryByCategoryLabeAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchSummaryReport("byCategoryLabel", eventKey);
+        return await FetchSummaryReport("byCategoryLabel", eventKey, cancellationToken);
     }
 
-    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryByCategoryLabelAsync(string eventKey)
+    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryByCategoryLabelAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchDeepSummaryReport("byCategoryLabel", eventKey);
+        return await FetchDeepSummaryReport("byCategoryLabel", eventKey, cancellationToken);
     }
 
-    public async Task<IEnumerable<EventObjectInfo>> ByCategoryLabelAsync(string eventKey, string categoryLabel)
+    public async Task<IEnumerable<EventObjectInfo>> ByCategoryLabelAsync(string eventKey, string categoryLabel, CancellationToken cancellationToken = default)
     {
-        return await FetchReport("byCategoryLabel", eventKey, categoryLabel);
+        return await FetchReport("byCategoryLabel", eventKey, categoryLabel, cancellationToken);
     }
 
-    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByCategoryKeyAsync(string eventKey)
+    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByCategoryKeyAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchReportAsync("byCategoryKey", eventKey);
+        return await FetchReportAsync("byCategoryKey", eventKey, cancellationToken);
     }
 
-    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryByCategoryKeyAsync(string eventKey)
+    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryByCategoryKeyAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchSummaryReport("byCategoryKey", eventKey);
+        return await FetchSummaryReport("byCategoryKey", eventKey, cancellationToken);
     }
 
-    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryByCategoryKeyAsync(string eventKey)
+    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryByCategoryKeyAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchDeepSummaryReport("byCategoryKey", eventKey);
+        return await FetchDeepSummaryReport("byCategoryKey", eventKey, cancellationToken);
     }
 
-    public async Task<IEnumerable<EventObjectInfo>> ByCategoryKeyAsync(string eventKey, string categoryKey)
+    public async Task<IEnumerable<EventObjectInfo>> ByCategoryKeyAsync(string eventKey, string categoryKey, CancellationToken cancellationToken = default)
     {
-        return await FetchReport("byCategoryKey", eventKey, categoryKey);
+        return await FetchReport("byCategoryKey", eventKey, categoryKey, cancellationToken);
     }
 
-    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByOrderIdAsync(string eventKey)
+    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByOrderIdAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchReportAsync("byOrderId", eventKey);
+        return await FetchReportAsync("byOrderId", eventKey, cancellationToken);
     }
 
-    public async Task<IEnumerable<EventObjectInfo>> ByOrderIdAsync(string eventKey, string categoryKey)
+    public async Task<IEnumerable<EventObjectInfo>> ByOrderIdAsync(string eventKey, string categoryKey, CancellationToken cancellationToken = default)
     {
-        return await FetchReport("byOrderId", eventKey, categoryKey);
+        return await FetchReport("byOrderId", eventKey, categoryKey, cancellationToken);
     }
 
-    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> BySectionAsync(string eventKey)
+    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> BySectionAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchReportAsync("bySection", eventKey);
+        return await FetchReportAsync("bySection", eventKey, cancellationToken);
     }
 
-    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryBySectionAsync(string eventKey)
+    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryBySectionAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchSummaryReport("bySection", eventKey);
+        return await FetchSummaryReport("bySection", eventKey, cancellationToken);
     }
 
-    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryBySectionAsync(string eventKey)
+    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryBySectionAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchDeepSummaryReport("bySection", eventKey);
+        return await FetchDeepSummaryReport("bySection", eventKey, cancellationToken);
     }
 
-    public async Task<IEnumerable<EventObjectInfo>> BySection(string eventKey, string section)
+    public async Task<IEnumerable<EventObjectInfo>> BySectionAsync(string eventKey, string section, CancellationToken cancellationToken = default)
     {
-        return await FetchReport("bySection", eventKey, section);
+        return await FetchReport("bySection", eventKey, section, cancellationToken);
     }
 
-    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByAvailabilityAsync(string eventKey)
+    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByAvailabilityAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchReportAsync("byAvailability", eventKey);
+        return await FetchReportAsync("byAvailability", eventKey, cancellationToken);
     }
 
-    public async Task<IEnumerable<EventObjectInfo>> ByAvailabilityAsync(string eventKey, string availability)
+    public async Task<IEnumerable<EventObjectInfo>> ByAvailabilityAsync(string eventKey, string availability, CancellationToken cancellationToken = default)
     {
-        return await FetchReport("byAvailability", eventKey, availability);
+        return await FetchReport("byAvailability", eventKey, availability, cancellationToken);
     }
 
-    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryByAvailabilityAsync(string eventKey)
+    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryByAvailabilityAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchSummaryReport("byAvailability", eventKey);
+        return await FetchSummaryReport("byAvailability", eventKey, cancellationToken);
     }
 
-    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryByAvailabilityAsync(string eventKey)
+    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryByAvailabilityAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchDeepSummaryReport("byAvailability", eventKey);
+        return await FetchDeepSummaryReport("byAvailability", eventKey, cancellationToken);
     }
 
-    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByAvailabilityReasonAsync(string eventKey)
+    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByAvailabilityReasonAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchReportAsync("byAvailabilityReason", eventKey);
+        return await FetchReportAsync("byAvailabilityReason", eventKey, cancellationToken);
     }
 
-    public async Task<IEnumerable<EventObjectInfo>> ByAvailabilityReasonAsync(string eventKey, string availabilityReason)
+    public async Task<IEnumerable<EventObjectInfo>> ByAvailabilityReasonAsync(string eventKey, string availabilityReason, CancellationToken cancellationToken = default)
     {
-        return await FetchReport("byAvailabilityReason", eventKey, availabilityReason);
+        return await FetchReport("byAvailabilityReason", eventKey, availabilityReason, cancellationToken);
     }
 
-    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryByAvailabilityReasonAsync(string eventKey)
+    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryByAvailabilityReasonAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchSummaryReport("byAvailabilityReason", eventKey);
+        return await FetchSummaryReport("byAvailabilityReason", eventKey, cancellationToken);
     }
 
-    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryByAvailabilityReasonAsync(string eventKey)
+    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryByAvailabilityReasonAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchDeepSummaryReport("byAvailabilityReason", eventKey);
+        return await FetchDeepSummaryReport("byAvailabilityReason", eventKey, cancellationToken);
     }
 
-    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByChannelAsync(string eventKey)
+    public async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> ByChannelAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchReportAsync("byChannel", eventKey);
+        return await FetchReportAsync("byChannel", eventKey, cancellationToken);
     }
 
-    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryByChannelAsync(string eventKey)
+    public async Task<Dictionary<string, EventReportSummaryItem>> SummaryByChannelAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchSummaryReport("byChannel", eventKey);
+        return await FetchSummaryReport("byChannel", eventKey, cancellationToken);
     }
 
-    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryByChannelAsync(string eventKey)
+    public async Task<Dictionary<string, EventReportDeepSummaryItem>> DeepSummaryByChannelAsync(string eventKey, CancellationToken cancellationToken = default)
     {
-        return await FetchDeepSummaryReport("byChannel", eventKey);
+        return await FetchDeepSummaryReport("byChannel", eventKey, cancellationToken);
     }
 
-    public async Task<IEnumerable<EventObjectInfo>> ByChannelAsync(string eventKey, string channelKey)
+    public async Task<IEnumerable<EventObjectInfo>> ByChannelAsync(string eventKey, string channelKey, CancellationToken cancellationToken = default)
     {
-        return await FetchReport("byChannel", eventKey, channelKey);
+        return await FetchReport("byChannel", eventKey, channelKey, cancellationToken);
     }
 
-    private async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> FetchReportAsync(string reportType, string eventKey)
+    private async Task<Dictionary<string, IEnumerable<EventObjectInfo>>> FetchReportAsync(string reportType, string eventKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/reports/events/{key}/{reportType}", Method.Get)
             .AddUrlSegment("key", eventKey)
             .AddUrlSegment("reportType", reportType);
-        return AssertOk(await _restClient.ExecuteAsync<Dictionary<string, IEnumerable<EventObjectInfo>>>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Dictionary<string, IEnumerable<EventObjectInfo>>>(restRequest, cancellationToken));
     }
 
-    private async Task<Dictionary<string, EventReportSummaryItem>> FetchSummaryReport(string reportType, string eventKey)
+    private async Task<Dictionary<string, EventReportSummaryItem>> FetchSummaryReport(string reportType, string eventKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/reports/events/{key}/{reportType}/summary", Method.Get)
             .AddUrlSegment("key", eventKey)
             .AddUrlSegment("reportType", reportType);
-        return AssertOk(await _restClient.ExecuteAsync<Dictionary<string, EventReportSummaryItem>>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Dictionary<string, EventReportSummaryItem>>(restRequest, cancellationToken));
     }
 
     private async Task<Dictionary<string, EventReportDeepSummaryItem>> FetchDeepSummaryReport(string reportType,
-        string eventKey)
+        string eventKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/reports/events/{key}/{reportType}/summary/deep", Method.Get)
             .AddUrlSegment("key", eventKey)
             .AddUrlSegment("reportType", reportType);
-        return AssertOk(await _restClient.ExecuteAsync<Dictionary<string, EventReportDeepSummaryItem>>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Dictionary<string, EventReportDeepSummaryItem>>(restRequest, cancellationToken));
     }
 
-    private async Task<IEnumerable<EventObjectInfo>> FetchReport(string reportType, string eventKey, string filter)
+    private async Task<IEnumerable<EventObjectInfo>> FetchReport(string reportType, string eventKey, string filter, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/reports/events/{key}/{reportType}/{filter}", Method.Get)
             .AddUrlSegment("key", eventKey)
             .AddUrlSegment("reportType", reportType)
             .AddUrlSegment("filter", filter);
-        var report = AssertOk(await _restClient.ExecuteAsync<Dictionary<string, IEnumerable<EventObjectInfo>>>(restRequest));
+        var report = AssertOk(await _restClient.ExecuteAsync<Dictionary<string, IEnumerable<EventObjectInfo>>>(restRequest, cancellationToken));
         if (report.ContainsKey(filter))
         {
             return report[filter];

--- a/SeatsioDotNet/Reports/Usage/UsageReports.cs
+++ b/SeatsioDotNet/Reports/Usage/UsageReports.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using RestSharp;
 using SeatsioDotNet.Reports.Usage.DetailsForEventInMonth;
@@ -18,31 +19,31 @@ public class UsageReports
         _restClient = restClient;
     }
 
-    public async Task<UsageSummaryForAllMonths> SummaryForAllMonthsAsync()
+    public async Task<UsageSummaryForAllMonths> SummaryForAllMonthsAsync(CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/reports/usage?version=2");
-        return AssertOk(await _restClient.ExecuteAsync<UsageSummaryForAllMonths>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<UsageSummaryForAllMonths>(restRequest, cancellationToken));
     }
 
-    public async Task<IEnumerable<UsageDetails>> DetailsForMonthAsync(UsageMonth month)
+    public async Task<IEnumerable<UsageDetails>> DetailsForMonthAsync(UsageMonth month, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/reports/usage/month/{month}")
             .AddUrlSegment("month", month.Serialize());
-        return AssertOk(await _restClient.ExecuteAsync<IEnumerable<UsageDetails>>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<IEnumerable<UsageDetails>>(restRequest, cancellationToken));
     }
 
-    public async Task<IEnumerable<object>> DetailsForEventInMonthAsync(long eventId, UsageMonth month)
+    public async Task<IEnumerable<object>> DetailsForEventInMonthAsync(long eventId, UsageMonth month, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/reports/usage/month/{month}/event/{event}")
             .AddUrlSegment("month", month.Serialize())
             .AddUrlSegment("event", eventId.ToString());
         if (month.Before(2022, 12))
         {
-            return AssertOk(await _restClient.ExecuteAsync<IEnumerable<UsageForObjectV1>>(restRequest));
+            return AssertOk(await _restClient.ExecuteAsync<IEnumerable<UsageForObjectV1>>(restRequest, cancellationToken));
         }
         else
         {
-            return AssertOk(await _restClient.ExecuteAsync<IEnumerable<UsageForObjectV2>>(restRequest));
+            return AssertOk(await _restClient.ExecuteAsync<IEnumerable<UsageForObjectV2>>(restRequest, cancellationToken));
         }
     }
 }

--- a/SeatsioDotNet/Reports/Usage/UsageReports.cs
+++ b/SeatsioDotNet/Reports/Usage/UsageReports.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using RestSharp;
 using SeatsioDotNet.Reports.Usage.DetailsForEventInMonth;
 using SeatsioDotNet.Reports.Usage.DetailsForMonth;
@@ -17,31 +18,31 @@ public class UsageReports
         _restClient = restClient;
     }
 
-    public UsageSummaryForAllMonths SummaryForAllMonths()
+    public async Task<UsageSummaryForAllMonths> SummaryForAllMonthsAsync()
     {
         var restRequest = new RestRequest("/reports/usage?version=2");
-        return AssertOk(_restClient.Execute<UsageSummaryForAllMonths>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<UsageSummaryForAllMonths>(restRequest));
     }
 
-    public IEnumerable<UsageDetails> DetailsForMonth(UsageMonth month)
+    public async Task<IEnumerable<UsageDetails>> DetailsForMonthAsync(UsageMonth month)
     {
         var restRequest = new RestRequest("/reports/usage/month/{month}")
             .AddUrlSegment("month", month.Serialize());
-        return AssertOk(_restClient.Execute<IEnumerable<UsageDetails>>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<IEnumerable<UsageDetails>>(restRequest));
     }
 
-    public IEnumerable<object> DetailsForEventInMonth(long eventId, UsageMonth month)
+    public async Task<IEnumerable<object>> DetailsForEventInMonthAsync(long eventId, UsageMonth month)
     {
         var restRequest = new RestRequest("/reports/usage/month/{month}/event/{event}")
             .AddUrlSegment("month", month.Serialize())
             .AddUrlSegment("event", eventId.ToString());
         if (month.Before(2022, 12))
         {
-            return AssertOk(_restClient.Execute<IEnumerable<UsageForObjectV1>>(restRequest));
+            return AssertOk(await _restClient.ExecuteAsync<IEnumerable<UsageForObjectV1>>(restRequest));
         }
         else
         {
-            return AssertOk(_restClient.Execute<IEnumerable<UsageForObjectV2>>(restRequest));
+            return AssertOk(await _restClient.ExecuteAsync<IEnumerable<UsageForObjectV2>>(restRequest));
         }
     }
 }

--- a/SeatsioDotNet/Seasons/Seasons.cs
+++ b/SeatsioDotNet/Seasons/Seasons.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using RestSharp;
 using SeatsioDotNet.Events;
 using static SeatsioDotNet.Util.RestUtil;
@@ -16,7 +17,7 @@ public class Seasons
         _seatsioClient = seatsioClient;
     }
 
-    public Event Create(string chartKey, string key = null, int? numberOfEvents = null, IEnumerable<string> eventKeys = null, TableBookingConfig tableBookingConfig = null, IEnumerable<Channel> channels = null, ForSaleConfig forSaleConfig = null)
+    public async Task<Event> CreateAsync(string chartKey, string key = null, int? numberOfEvents = null, IEnumerable<string> eventKeys = null, TableBookingConfig tableBookingConfig = null, IEnumerable<Channel> channels = null, ForSaleConfig forSaleConfig = null)
     {
         Dictionary<string, object> requestBody = new Dictionary<string, object>();
         requestBody.Add("chartKey", chartKey);
@@ -52,10 +53,10 @@ public class Seasons
         }
             
         var restRequest = new RestRequest("/seasons", Method.Post).AddJsonBody(requestBody);
-        return AssertOk(_restClient.Execute<Event>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Event>(restRequest));
     }
 
-    public Event CreatePartialSeason(string topLevelSeasonKey, string partialSeasonKey = null, IEnumerable<string> eventKeys = null)
+    public async Task<Event> CreatePartialSeasonAsync(string topLevelSeasonKey, string partialSeasonKey = null, IEnumerable<string> eventKeys = null)
     {
         Dictionary<string, object> requestBody = new Dictionary<string, object>();
             
@@ -72,15 +73,15 @@ public class Seasons
         var restRequest = new RestRequest("/seasons/{topLevelSeasonKey}/partial-seasons", Method.Post)
             .AddUrlSegment("topLevelSeasonKey", topLevelSeasonKey)
             .AddJsonBody(requestBody);
-        return AssertOk(_restClient.Execute<Event>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Event>(restRequest));
     }
 
-    public Event Retrieve(string key)
+    public async Task<Event> RetrieveAsync(string key)
     {
-        return _seatsioClient.Events.Retrieve(key);
+        return await _seatsioClient.Events.RetrieveAsync(key);
     }
 
-    public Event AddEventsToPartialSeason(string topLevelSeasonKey, string partialSeasonKey, string[] eventKeys)
+    public async Task<Event> AddEventsToPartialSeasonAsync(string topLevelSeasonKey, string partialSeasonKey, string[] eventKeys)
     {
         Dictionary<string, object> requestBody = new Dictionary<string, object>();
         requestBody.Add("eventKeys", eventKeys);
@@ -88,19 +89,19 @@ public class Seasons
             .AddUrlSegment("topLevelSeasonKey", topLevelSeasonKey)
             .AddUrlSegment("partialSeasonKey", partialSeasonKey)
             .AddJsonBody(requestBody);
-        return AssertOk(_restClient.Execute<Event>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Event>(restRequest));
     }
 
-    public Event RemoveEventFromPartialSeason(string topLevelSeasonKey, string partialSeasonKey, string eventKey)
+    public async Task<Event> RemoveEventFromPartialSeasonAsync(string topLevelSeasonKey, string partialSeasonKey, string eventKey)
     {
         var restRequest = new RestRequest("/seasons/{topLevelSeasonKey}/partial-seasons/{partialSeasonKey}/events/{eventKey}", Method.Delete)
             .AddUrlSegment("topLevelSeasonKey", topLevelSeasonKey)
             .AddUrlSegment("partialSeasonKey", partialSeasonKey)
             .AddUrlSegment("eventKey", eventKey);
-        return AssertOk(_restClient.Execute<Event>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Event>(restRequest));
     }
 
-    public Event[] CreateEvents(string key, string[] eventKeys = null, int? numberOfEvents = null)
+    public async Task<Event[]> CreateEventsAsync(string key, string[] eventKeys = null, int? numberOfEvents = null)
     {
         Dictionary<string, object> requestBody = new Dictionary<string, object>();
 
@@ -117,6 +118,6 @@ public class Seasons
         var restRequest = new RestRequest("/seasons/{key}/actions/create-events", Method.Post)
             .AddUrlSegment("key", key)
             .AddJsonBody(requestBody);
-        return AssertOk(_restClient.Execute<MultipleEvents>(restRequest)).events.ToArray();
+        return AssertOk(await _restClient.ExecuteAsync<MultipleEvents>(restRequest)).events.ToArray();
     }
 }

--- a/SeatsioDotNet/Seasons/Seasons.cs
+++ b/SeatsioDotNet/Seasons/Seasons.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using RestSharp;
 using SeatsioDotNet.Events;
@@ -17,7 +18,7 @@ public class Seasons
         _seatsioClient = seatsioClient;
     }
 
-    public async Task<Event> CreateAsync(string chartKey, string key = null, int? numberOfEvents = null, IEnumerable<string> eventKeys = null, TableBookingConfig tableBookingConfig = null, IEnumerable<Channel> channels = null, ForSaleConfig forSaleConfig = null)
+    public async Task<Event> CreateAsync(string chartKey, string key = null, int? numberOfEvents = null, IEnumerable<string> eventKeys = null, TableBookingConfig tableBookingConfig = null, IEnumerable<Channel> channels = null, ForSaleConfig forSaleConfig = null, CancellationToken cancellationToken = default)
     {
         Dictionary<string, object> requestBody = new Dictionary<string, object>();
         requestBody.Add("chartKey", chartKey);
@@ -53,10 +54,10 @@ public class Seasons
         }
             
         var restRequest = new RestRequest("/seasons", Method.Post).AddJsonBody(requestBody);
-        return AssertOk(await _restClient.ExecuteAsync<Event>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Event>(restRequest, cancellationToken));
     }
 
-    public async Task<Event> CreatePartialSeasonAsync(string topLevelSeasonKey, string partialSeasonKey = null, IEnumerable<string> eventKeys = null)
+    public async Task<Event> CreatePartialSeasonAsync(string topLevelSeasonKey, string partialSeasonKey = null, IEnumerable<string> eventKeys = null, CancellationToken cancellationToken = default)
     {
         Dictionary<string, object> requestBody = new Dictionary<string, object>();
             
@@ -73,15 +74,15 @@ public class Seasons
         var restRequest = new RestRequest("/seasons/{topLevelSeasonKey}/partial-seasons", Method.Post)
             .AddUrlSegment("topLevelSeasonKey", topLevelSeasonKey)
             .AddJsonBody(requestBody);
-        return AssertOk(await _restClient.ExecuteAsync<Event>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Event>(restRequest, cancellationToken));
     }
 
-    public async Task<Event> RetrieveAsync(string key)
+    public async Task<Event> RetrieveAsync(string key, CancellationToken cancellationToken = default)
     {
-        return await _seatsioClient.Events.RetrieveAsync(key);
+        return await _seatsioClient.Events.RetrieveAsync(key, cancellationToken);
     }
 
-    public async Task<Event> AddEventsToPartialSeasonAsync(string topLevelSeasonKey, string partialSeasonKey, string[] eventKeys)
+    public async Task<Event> AddEventsToPartialSeasonAsync(string topLevelSeasonKey, string partialSeasonKey, string[] eventKeys, CancellationToken cancellationToken = default)
     {
         Dictionary<string, object> requestBody = new Dictionary<string, object>();
         requestBody.Add("eventKeys", eventKeys);
@@ -89,19 +90,19 @@ public class Seasons
             .AddUrlSegment("topLevelSeasonKey", topLevelSeasonKey)
             .AddUrlSegment("partialSeasonKey", partialSeasonKey)
             .AddJsonBody(requestBody);
-        return AssertOk(await _restClient.ExecuteAsync<Event>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Event>(restRequest, cancellationToken));
     }
 
-    public async Task<Event> RemoveEventFromPartialSeasonAsync(string topLevelSeasonKey, string partialSeasonKey, string eventKey)
+    public async Task<Event> RemoveEventFromPartialSeasonAsync(string topLevelSeasonKey, string partialSeasonKey, string eventKey, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/seasons/{topLevelSeasonKey}/partial-seasons/{partialSeasonKey}/events/{eventKey}", Method.Delete)
             .AddUrlSegment("topLevelSeasonKey", topLevelSeasonKey)
             .AddUrlSegment("partialSeasonKey", partialSeasonKey)
             .AddUrlSegment("eventKey", eventKey);
-        return AssertOk(await _restClient.ExecuteAsync<Event>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Event>(restRequest, cancellationToken));
     }
 
-    public async Task<Event[]> CreateEventsAsync(string key, string[] eventKeys = null, int? numberOfEvents = null)
+    public async Task<Event[]> CreateEventsAsync(string key, string[] eventKeys = null, int? numberOfEvents = null, CancellationToken cancellationToken = default)
     {
         Dictionary<string, object> requestBody = new Dictionary<string, object>();
 
@@ -118,6 +119,6 @@ public class Seasons
         var restRequest = new RestRequest("/seasons/{key}/actions/create-events", Method.Post)
             .AddUrlSegment("key", key)
             .AddJsonBody(requestBody);
-        return AssertOk(await _restClient.ExecuteAsync<MultipleEvents>(restRequest)).events.ToArray();
+        return AssertOk(await _restClient.ExecuteAsync<MultipleEvents>(restRequest, cancellationToken)).events.ToArray();
     }
 }

--- a/SeatsioDotNet/SeatsioClient.cs
+++ b/SeatsioDotNet/SeatsioClient.cs
@@ -62,7 +62,8 @@ namespace SeatsioDotNet
             };
             var client = new SeatsioRestClient(options);
             client.AddDefaultHeader("X-Client-Lib", ".NET");
-            if (workspaceKey != null)
+            
+            if (!string.IsNullOrEmpty(workspaceKey))
             {
                 client.AddDefaultHeader("X-Workspace-Key", workspaceKey.ToString());
             }
@@ -109,7 +110,7 @@ public class SeatsioMessageHandler : HttpClientHandler
         {
             var waitTime = (int) Math.Pow(2, retryCount + 2) * 100;
             retryCount++;
-            Thread.Sleep(waitTime);
+            await Task.Delay(waitTime, cancellationToken);
             response = await base.SendAsync(request, cancellationToken);
         }
 

--- a/SeatsioDotNet/Util/Lister.cs
+++ b/SeatsioDotNet/Util/Lister.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SeatsioDotNet.Util;
@@ -17,18 +18,18 @@ public class Lister<T>
         return new PagedEnumerable<T>(_pageFetcher, listParams);
     }
 
-    public async Task<Page<T>> FirstPageAsync(int? pageSize = null)
+    public async Task<Page<T>> FirstPageAsync(int? pageSize = null, CancellationToken cancellationToken = default)
     {
-        return await _pageFetcher.FetchFirstPageAsync(pageSize: pageSize);
+        return await _pageFetcher.FetchFirstPageAsync(pageSize: pageSize, cancellationToken:cancellationToken);
     }
 
-    public async Task<Page<T>> PageAfterAsync(long id, int? pageSize = null)
+    public async Task<Page<T>> PageAfterAsync(long id, int? pageSize = null, CancellationToken cancellationToken = default)
     {
-        return await _pageFetcher.FetchAfterAsync(id, pageSize: pageSize);
+        return await _pageFetcher.FetchAfterAsync(id, pageSize: pageSize, cancellationToken:cancellationToken);
     }
 
-    public async Task<Page<T>> PageBeforeAsync(long id, int? pageSize = null)
+    public async Task<Page<T>> PageBeforeAsync(long id, int? pageSize = null, CancellationToken cancellationToken = default)
     {
-        return await _pageFetcher.FetchBeforeAsync(id, pageSize: pageSize);
+        return await _pageFetcher.FetchBeforeAsync(id, pageSize: pageSize, cancellationToken:cancellationToken);
     }
 }

--- a/SeatsioDotNet/Util/Lister.cs
+++ b/SeatsioDotNet/Util/Lister.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace SeatsioDotNet.Util;
 
@@ -11,23 +12,23 @@ public class Lister<T>
         _pageFetcher = pageFetcher;
     }
 
-    public IEnumerable<T> All(Dictionary<string, object> listParams = null)
+    public IAsyncEnumerable<T> AllAsync(Dictionary<string, object> listParams = null)
     {
         return new PagedEnumerable<T>(_pageFetcher, listParams);
     }
 
-    public Page<T> FirstPage(int? pageSize = null)
+    public async Task<Page<T>> FirstPageAsync(int? pageSize = null)
     {
-        return _pageFetcher.FetchFirstPage(pageSize: pageSize);
+        return await _pageFetcher.FetchFirstPageAsync(pageSize: pageSize);
     }
 
-    public Page<T> PageAfter(long id, int? pageSize = null)
+    public async Task<Page<T>> PageAfterAsync(long id, int? pageSize = null)
     {
-        return _pageFetcher.FetchAfter(id, pageSize: pageSize);
+        return await _pageFetcher.FetchAfterAsync(id, pageSize: pageSize);
     }
 
-    public Page<T> PageBefore(long id, int? pageSize = null)
+    public async Task<Page<T>> PageBeforeAsync(long id, int? pageSize = null)
     {
-        return _pageFetcher.FetchBefore(id, pageSize: pageSize);
+        return await _pageFetcher.FetchBeforeAsync(id, pageSize: pageSize);
     }
 }

--- a/SeatsioDotNet/Util/PageFetcher.cs
+++ b/SeatsioDotNet/Util/PageFetcher.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using RestSharp;
 using static SeatsioDotNet.Util.RestUtil;
@@ -34,22 +35,22 @@ public class PageFetcher<T>
         _queryParams = queryParams;
     }
 
-    public async Task<Page<T>> FetchFirstPageAsync(Dictionary<string, object> listParams = null, int? pageSize = null)
+    public async Task<Page<T>> FetchFirstPageAsync(Dictionary<string, object> listParams = null, int? pageSize = null, CancellationToken cancellationToken = default)
     {
         var restRequest = BuildRequest(listParams, pageSize);
-        return AssertOk(await _restClient.ExecuteAsync<Page<T>>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Page<T>>(restRequest, cancellationToken));
     }
 
-    public async Task<Page<T>> FetchAfterAsync(long id, Dictionary<string, object> listParams = null, int? pageSize = null)
+    public async Task<Page<T>> FetchAfterAsync(long id, Dictionary<string, object> listParams = null, int? pageSize = null, CancellationToken cancellationToken = default)
     {
         var restRequest = BuildRequest(listParams, pageSize).AddQueryParameter("start_after_id", id.ToString());
-        return AssertOk(await _restClient.ExecuteAsync<Page<T>>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Page<T>>(restRequest, cancellationToken));
     }
 
-    public async Task<Page<T>> FetchBeforeAsync(long id, Dictionary<string, object> listParams = null, int? pageSize = null)
+    public async Task<Page<T>> FetchBeforeAsync(long id, Dictionary<string, object> listParams = null, int? pageSize = null, CancellationToken cancellationToken = default)
     {
         var restRequest = BuildRequest(listParams, pageSize).AddQueryParameter("end_before_id", id.ToString());
-        return AssertOk(await _restClient.ExecuteAsync<Page<T>>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Page<T>>(restRequest, cancellationToken));
     }
 
     private RestRequest BuildRequest(Dictionary<string, object> listParams, int? pageSize)

--- a/SeatsioDotNet/Util/PageFetcher.cs
+++ b/SeatsioDotNet/Util/PageFetcher.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using RestSharp;
 using static SeatsioDotNet.Util.RestUtil;
 
@@ -33,22 +34,22 @@ public class PageFetcher<T>
         _queryParams = queryParams;
     }
 
-    public Page<T> FetchFirstPage(Dictionary<string, object> listParams = null, int? pageSize = null)
+    public async Task<Page<T>> FetchFirstPageAsync(Dictionary<string, object> listParams = null, int? pageSize = null)
     {
         var restRequest = BuildRequest(listParams, pageSize);
-        return AssertOk(_restClient.Execute<Page<T>>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Page<T>>(restRequest));
     }
 
-    public Page<T> FetchAfter(long id, Dictionary<string, object> listParams = null, int? pageSize = null)
+    public async Task<Page<T>> FetchAfterAsync(long id, Dictionary<string, object> listParams = null, int? pageSize = null)
     {
         var restRequest = BuildRequest(listParams, pageSize).AddQueryParameter("start_after_id", id.ToString());
-        return AssertOk(_restClient.Execute<Page<T>>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Page<T>>(restRequest));
     }
 
-    public Page<T> FetchBefore(long id, Dictionary<string, object> listParams = null, int? pageSize = null)
+    public async Task<Page<T>> FetchBeforeAsync(long id, Dictionary<string, object> listParams = null, int? pageSize = null)
     {
         var restRequest = BuildRequest(listParams, pageSize).AddQueryParameter("end_before_id", id.ToString());
-        return AssertOk(_restClient.Execute<Page<T>>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Page<T>>(restRequest));
     }
 
     private RestRequest BuildRequest(Dictionary<string, object> listParams, int? pageSize)

--- a/SeatsioDotNet/Util/PagedEnumerable.cs
+++ b/SeatsioDotNet/Util/PagedEnumerable.cs
@@ -1,9 +1,10 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace SeatsioDotNet.Util;
 
-public class PagedEnumerable<T> : IEnumerable<T>
+public class PagedEnumerable<T> : IAsyncEnumerable<T>
 {
     private readonly PagedEnumerator<T> _pagedEnumerator;
 
@@ -12,13 +13,13 @@ public class PagedEnumerable<T> : IEnumerable<T>
         _pagedEnumerator = new PagedEnumerator<T>(pageFetcher, listParams);
     }
 
-    public IEnumerator<T> GetEnumerator()
+    public IAsyncEnumerator<T> GetAsyncEnumerator()
     {
         return _pagedEnumerator;
     }
 
-    IEnumerator IEnumerable.GetEnumerator()
+    public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = new CancellationToken())
     {
-        return GetEnumerator();
+        return GetAsyncEnumerator();
     }
 }

--- a/SeatsioDotNet/Util/PagedEnumerable.cs
+++ b/SeatsioDotNet/Util/PagedEnumerable.cs
@@ -1,25 +1,21 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading;
 
 namespace SeatsioDotNet.Util;
 
 public class PagedEnumerable<T> : IAsyncEnumerable<T>
 {
-    private readonly PagedEnumerator<T> _pagedEnumerator;
+    private readonly PageFetcher<T> _pageFetcher;
+    private readonly Dictionary<string, object> _listParams;
 
     public PagedEnumerable(PageFetcher<T> pageFetcher, Dictionary<string, object> listParams)
     {
-        _pagedEnumerator = new PagedEnumerator<T>(pageFetcher, listParams);
+        _pageFetcher = pageFetcher;
+        _listParams = listParams;
     }
 
-    public IAsyncEnumerator<T> GetAsyncEnumerator()
+    public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
     {
-        return _pagedEnumerator;
-    }
-
-    public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = new CancellationToken())
-    {
-        return GetAsyncEnumerator();
+        return  new PagedEnumerator<T>(_pageFetcher, _listParams, cancellationToken);
     }
 }

--- a/SeatsioDotNet/Util/PagedEnumerator.cs
+++ b/SeatsioDotNet/Util/PagedEnumerator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SeatsioDotNet.Util;
@@ -11,22 +12,24 @@ public class PagedEnumerator<T> : IAsyncEnumerator<T>
         
     private readonly PageFetcher<T> _pageFetcher;
     private readonly Dictionary<string, object> _listParams;
+    private readonly CancellationToken _cancellationToken;
 
-    public PagedEnumerator(PageFetcher<T> pageFetcher, Dictionary<string, object> listParams)
+    public PagedEnumerator(PageFetcher<T> pageFetcher, Dictionary<string, object> listParams, CancellationToken cancellationToken = default)
     {
         _pageFetcher = pageFetcher;
         _listParams = listParams;
+        _cancellationToken = cancellationToken;
     }
 
     public async ValueTask<bool> MoveNextAsync()
     {
         if (_currentPage == null)
         {
-            _currentPage = await _pageFetcher.FetchFirstPageAsync(_listParams, null);
+            _currentPage = await _pageFetcher.FetchFirstPageAsync(_listParams, null, cancellationToken:_cancellationToken);
         }
         else if (NextPageMustBeFetched())
         {
-            _currentPage = await _pageFetcher.FetchAfterAsync(_currentPage.NextPageStartsAfter.Value, _listParams, null);
+            _currentPage = await _pageFetcher.FetchAfterAsync(_currentPage.NextPageStartsAfter.Value, _listParams, null, cancellationToken:_cancellationToken);
             _indexInCurrentPage = 0;
         }
         else

--- a/SeatsioDotNet/Util/PagedEnumerator.cs
+++ b/SeatsioDotNet/Util/PagedEnumerator.cs
@@ -1,9 +1,10 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace SeatsioDotNet.Util;
 
-public class PagedEnumerator<T> : IEnumerator<T>
+public class PagedEnumerator<T> : IAsyncEnumerator<T>
 {
     private Page<T> _currentPage;
     private int _indexInCurrentPage;
@@ -17,15 +18,15 @@ public class PagedEnumerator<T> : IEnumerator<T>
         _listParams = listParams;
     }
 
-    public bool MoveNext()
+    public async ValueTask<bool> MoveNextAsync()
     {
         if (_currentPage == null)
         {
-            _currentPage = _pageFetcher.FetchFirstPage(_listParams, null);
+            _currentPage = await _pageFetcher.FetchFirstPageAsync(_listParams, null);
         }
         else if (NextPageMustBeFetched())
         {
-            _currentPage = _pageFetcher.FetchAfter(_currentPage.NextPageStartsAfter.Value, _listParams, null);
+            _currentPage = await _pageFetcher.FetchAfterAsync(_currentPage.NextPageStartsAfter.Value, _listParams, null);
             _indexInCurrentPage = 0;
         }
         else
@@ -50,9 +51,10 @@ public class PagedEnumerator<T> : IEnumerator<T>
 
     public T Current => _currentPage.Items[_indexInCurrentPage];
 
-    object IEnumerator.Current => Current;
+    T IAsyncEnumerator<T>.Current => Current;
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
+        return ValueTask.CompletedTask;
     }
 }

--- a/SeatsioDotNet/Util/ParametrizedLister.cs
+++ b/SeatsioDotNet/Util/ParametrizedLister.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace SeatsioDotNet.Util;
 
@@ -11,23 +12,23 @@ public class ParametrizedLister<T>
         _pageFetcher = pageFetcher;
     }
 
-    public IEnumerable<T> All(Dictionary<string, object> listParams = null)
+    public IAsyncEnumerable<T> All(Dictionary<string, object> listParams = null)
     {
         return new PagedEnumerable<T>(_pageFetcher, listParams);
     }
 
-    public Page<T> FirstPage(Dictionary<string, object> listParams = null, int? pageSize = null)
+    public async Task<Page<T>> FirstPage(Dictionary<string, object> listParams = null, int? pageSize = null)
     {
-        return _pageFetcher.FetchFirstPage(listParams, pageSize);
+        return await _pageFetcher.FetchFirstPageAsync(listParams, pageSize);
     }
 
-    public Page<T> PageAfter(long id, Dictionary<string, object> listParams = null, int? pageSize = null)
+    public async Task<Page<T>> PageAfter(long id, Dictionary<string, object> listParams = null, int? pageSize = null)
     {
-        return _pageFetcher.FetchAfter(id, listParams, pageSize);
+        return await _pageFetcher.FetchAfterAsync(id, listParams, pageSize);
     }
 
-    public Page<T> PageBefore(long id, Dictionary<string, object> listParams = null, int? pageSize = null)
+    public async Task<Page<T>> PageBefore(long id, Dictionary<string, object> listParams = null, int? pageSize = null)
     {
-        return _pageFetcher.FetchBefore(id, listParams, pageSize);
+        return await _pageFetcher.FetchBeforeAsync(id, listParams, pageSize);
     }
 }

--- a/SeatsioDotNet/Util/ParametrizedLister.cs
+++ b/SeatsioDotNet/Util/ParametrizedLister.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SeatsioDotNet.Util;
@@ -12,23 +13,23 @@ public class ParametrizedLister<T>
         _pageFetcher = pageFetcher;
     }
 
-    public IAsyncEnumerable<T> All(Dictionary<string, object> listParams = null)
+    public IAsyncEnumerable<T> AllAsync(Dictionary<string, object> listParams = null)
     {
         return new PagedEnumerable<T>(_pageFetcher, listParams);
     }
 
-    public async Task<Page<T>> FirstPage(Dictionary<string, object> listParams = null, int? pageSize = null)
+    public async Task<Page<T>> FirstPageAsync(Dictionary<string, object> listParams = null, int? pageSize = null, CancellationToken cancellationToken = default)
     {
-        return await _pageFetcher.FetchFirstPageAsync(listParams, pageSize);
+        return await _pageFetcher.FetchFirstPageAsync(listParams, pageSize, cancellationToken:cancellationToken);
     }
 
-    public async Task<Page<T>> PageAfter(long id, Dictionary<string, object> listParams = null, int? pageSize = null)
+    public async Task<Page<T>> PageAfterAsync(long id, Dictionary<string, object> listParams = null, int? pageSize = null, CancellationToken cancellationToken = default)
     {
-        return await _pageFetcher.FetchAfterAsync(id, listParams, pageSize);
+        return await _pageFetcher.FetchAfterAsync(id, listParams, pageSize, cancellationToken);
     }
 
-    public async Task<Page<T>> PageBefore(long id, Dictionary<string, object> listParams = null, int? pageSize = null)
+    public async Task<Page<T>> PageBeforeAsync(long id, Dictionary<string, object> listParams = null, int? pageSize = null, CancellationToken cancellationToken = default)
     {
-        return await _pageFetcher.FetchBeforeAsync(id, listParams, pageSize);
+        return await _pageFetcher.FetchBeforeAsync(id, listParams, pageSize, cancellationToken);
     }
 }

--- a/SeatsioDotNet/Workspaces/WorkspaceLister.cs
+++ b/SeatsioDotNet/Workspaces/WorkspaceLister.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using SeatsioDotNet.Events;
 using SeatsioDotNet.Util;
 
@@ -13,24 +14,24 @@ public class WorkspaceLister
         _pageFetcher = pageFetcher;
     }
 
-    public IEnumerable<Workspace> All(string filter = null)
+    public IAsyncEnumerable<Workspace> All(string filter = null)
     {
         return new PagedEnumerable<Workspace>(_pageFetcher, WorkspaceListParams(filter));
     }
 
-    public Page<Workspace> FirstPage(string filter = null, int? pageSize = null)
+    public async Task<Page<Workspace>> FirstPage(string filter = null, int? pageSize = null)
     {
-        return _pageFetcher.FetchFirstPage(WorkspaceListParams(filter), pageSize);
+        return await _pageFetcher.FetchFirstPageAsync(WorkspaceListParams(filter), pageSize);
     }
 
-    public Page<Workspace> PageAfter(long id, string filter = null, int? pageSize = null)
+    public async Task<Page<Workspace>> PageAfter(long id, string filter = null, int? pageSize = null)
     {
-        return _pageFetcher.FetchAfter(id, WorkspaceListParams(filter), pageSize);
+        return await _pageFetcher.FetchAfterAsync(id, WorkspaceListParams(filter), pageSize);
     }
 
-    public Page<Workspace> PageBefore(long id, string filter = null, int? pageSize = null)
+    public async Task<Page<Workspace>> PageBefore(long id, string filter = null, int? pageSize = null)
     {
-        return _pageFetcher.FetchBefore(id, WorkspaceListParams(filter), pageSize);
+        return await _pageFetcher.FetchBeforeAsync(id, WorkspaceListParams(filter), pageSize);
     }
         
     private static Dictionary<string, object> WorkspaceListParams(string filter)

--- a/SeatsioDotNet/Workspaces/WorkspaceLister.cs
+++ b/SeatsioDotNet/Workspaces/WorkspaceLister.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using SeatsioDotNet.Events;
 using SeatsioDotNet.Util;
@@ -14,24 +15,24 @@ public class WorkspaceLister
         _pageFetcher = pageFetcher;
     }
 
-    public IAsyncEnumerable<Workspace> All(string filter = null)
+    public IAsyncEnumerable<Workspace> AllAsync(string filter = null)
     {
         return new PagedEnumerable<Workspace>(_pageFetcher, WorkspaceListParams(filter));
     }
 
-    public async Task<Page<Workspace>> FirstPage(string filter = null, int? pageSize = null)
+    public async Task<Page<Workspace>> FirstPageAsync(string filter = null, int? pageSize = null, CancellationToken cancellationToken = default)
     {
-        return await _pageFetcher.FetchFirstPageAsync(WorkspaceListParams(filter), pageSize);
+        return await _pageFetcher.FetchFirstPageAsync(WorkspaceListParams(filter), pageSize, cancellationToken:cancellationToken);
     }
 
-    public async Task<Page<Workspace>> PageAfter(long id, string filter = null, int? pageSize = null)
+    public async Task<Page<Workspace>> PageAfterAsync(long id, string filter = null, int? pageSize = null, CancellationToken cancellationToken = default)
     {
-        return await _pageFetcher.FetchAfterAsync(id, WorkspaceListParams(filter), pageSize);
+        return await _pageFetcher.FetchAfterAsync(id, WorkspaceListParams(filter), pageSize, cancellationToken:cancellationToken);
     }
 
-    public async Task<Page<Workspace>> PageBefore(long id, string filter = null, int? pageSize = null)
+    public async Task<Page<Workspace>> PageBeforeAsync(long id, string filter = null, int? pageSize = null, CancellationToken cancellationToken = default)
     {
-        return await _pageFetcher.FetchBeforeAsync(id, WorkspaceListParams(filter), pageSize);
+        return await _pageFetcher.FetchBeforeAsync(id, WorkspaceListParams(filter), pageSize, cancellationToken:cancellationToken);
     }
         
     private static Dictionary<string, object> WorkspaceListParams(string filter)

--- a/SeatsioDotNet/Workspaces/Workspaces.cs
+++ b/SeatsioDotNet/Workspaces/Workspaces.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using RestSharp;
 using SeatsioDotNet.Events;
@@ -21,7 +22,7 @@ public class Workspaces
         Inactive = new WorkspaceLister(new PageFetcher<Workspace>(_restClient, "/workspaces/inactive"));
     }
 
-    public async Task<Workspace> CreateAsync(string name, bool? isTest = null)
+    public async Task<Workspace> CreateAsync(string name, bool? isTest = null, CancellationToken cancellationToken = default)
     {
         Dictionary<string, object> requestBody = new Dictionary<string, object>();
         requestBody.Add("name", name);
@@ -32,73 +33,73 @@ public class Workspaces
         }
 
         var restRequest = new RestRequest("/workspaces", Method.Post).AddJsonBody(requestBody);
-        return AssertOk(await _restClient.ExecuteAsync<Workspace>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Workspace>(restRequest, cancellationToken));
     }
 
-    public async Task<Workspace> RetrieveAsync(string key)
+    public async Task<Workspace> RetrieveAsync(string key, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/workspaces/{key}", Method.Get)
             .AddUrlSegment("key", key);
-        return AssertOk(await _restClient.ExecuteAsync<Workspace>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Workspace>(restRequest, cancellationToken));
     }
 
-    public async Task UpdateAsync(string key, string name)
+    public async Task UpdateAsync(string key, string name, CancellationToken cancellationToken = default)
     {
         Dictionary<string, object> requestBody = new Dictionary<string, object>();
         requestBody.Add("name", name);
 
         var restRequest = new RestRequest("/workspaces/{key}", Method.Post).AddJsonBody(requestBody)
             .AddUrlSegment("key", key);
-        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest, cancellationToken));
     }
 
-    public async Task<string> RegenerateSecretKeyAsync(string key)
+    public async Task<string> RegenerateSecretKeyAsync(string key, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/workspaces/{key}/actions/regenerate-secret-key", Method.Post)
             .AddUrlSegment("key", key);
-        var response = AssertOk(await _restClient.ExecuteAsync<Dictionary<string, string>>(restRequest));
+        var response = AssertOk(await _restClient.ExecuteAsync<Dictionary<string, string>>(restRequest, cancellationToken));
         return response["secretKey"];
     }  
         
-    public async Task ActivateAsync(string key)
+    public async Task ActivateAsync(string key, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/workspaces/{key}/actions/activate", Method.Post)
             .AddUrlSegment("key", key);
-        AssertOk(await _restClient.ExecuteAsync<Dictionary<string, string>>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<Dictionary<string, string>>(restRequest, cancellationToken));
     }   
         
-    public async Task DeactivateAsync(string key)
+    public async Task DeactivateAsync(string key, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/workspaces/{key}/actions/deactivate", Method.Post)
             .AddUrlSegment("key", key);
-        AssertOk(await _restClient.ExecuteAsync<Dictionary<string, string>>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<Dictionary<string, string>>(restRequest, cancellationToken));
     }  
         
-    public async Task SetDefaultAsync(string key)
+    public async Task SetDefaultAsync(string key, CancellationToken cancellationToken = default)
     {
         var restRequest = new RestRequest("/workspaces/actions/set-default/{key}", Method.Post)
             .AddUrlSegment("key", key);
-        AssertOk(await _restClient.ExecuteAsync<Dictionary<string, string>>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<Dictionary<string, string>>(restRequest, cancellationToken));
     }
 
     public IAsyncEnumerable<Workspace> ListAllAsync(string filter = null)
     {
-        return ParametrizedList().All(filter);
+        return ParametrizedList().AllAsync(filter);
     }
 
-    public async Task<Page<Workspace>> ListFirstPageAsync(int? pageSize = null, string filter = null)
+    public async Task<Page<Workspace>> ListFirstPageAsync(int? pageSize = null, string filter = null, CancellationToken cancellationToken = default)
     {
-        return await ParametrizedList().FirstPage(filter, pageSize);
+        return await ParametrizedList().FirstPageAsync(filter, pageSize, cancellationToken:cancellationToken);
     }
 
-    public async Task<Page<Workspace>> ListPageAfterAsync(long id, int? pageSize = null, string filter = null)
+    public async Task<Page<Workspace>> ListPageAfterAsync(long id, int? pageSize = null, string filter = null, CancellationToken cancellationToken = default)
     {
-        return await ParametrizedList().PageAfter(id, filter, pageSize);
+        return await ParametrizedList().PageAfterAsync(id, filter, pageSize, cancellationToken:cancellationToken);
     }
 
-    public async Task<Page<Workspace>> ListPageBeforeAsync(long id, int? pageSize = null, string filter = null)
+    public async Task<Page<Workspace>> ListPageBeforeAsync(long id, int? pageSize = null, string filter = null, CancellationToken cancellationToken = default)
     {
-        return await ParametrizedList().PageBefore(id, filter, pageSize);
+        return await ParametrizedList().PageBeforeAsync(id, filter, pageSize, cancellationToken:cancellationToken);
     }
 
     private WorkspaceLister ParametrizedList()

--- a/SeatsioDotNet/Workspaces/Workspaces.cs
+++ b/SeatsioDotNet/Workspaces/Workspaces.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using RestSharp;
 using SeatsioDotNet.Events;
 using SeatsioDotNet.Util;
@@ -20,12 +21,7 @@ public class Workspaces
         Inactive = new WorkspaceLister(new PageFetcher<Workspace>(_restClient, "/workspaces/inactive"));
     }
 
-    public Workspace Create(string name)
-    {
-        return Create(name, null);
-    }
-
-    public Workspace Create(string name, bool? isTest)
+    public async Task<Workspace> CreateAsync(string name, bool? isTest = null)
     {
         Dictionary<string, object> requestBody = new Dictionary<string, object>();
         requestBody.Add("name", name);
@@ -36,73 +32,73 @@ public class Workspaces
         }
 
         var restRequest = new RestRequest("/workspaces", Method.Post).AddJsonBody(requestBody);
-        return AssertOk(_restClient.Execute<Workspace>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Workspace>(restRequest));
     }
 
-    public Workspace Retrieve(string key)
+    public async Task<Workspace> RetrieveAsync(string key)
     {
         var restRequest = new RestRequest("/workspaces/{key}", Method.Get)
             .AddUrlSegment("key", key);
-        return AssertOk(_restClient.Execute<Workspace>(restRequest));
+        return AssertOk(await _restClient.ExecuteAsync<Workspace>(restRequest));
     }
 
-    public void Update(string key, string name)
+    public async Task UpdateAsync(string key, string name)
     {
         Dictionary<string, object> requestBody = new Dictionary<string, object>();
         requestBody.Add("name", name);
 
         var restRequest = new RestRequest("/workspaces/{key}", Method.Post).AddJsonBody(requestBody)
             .AddUrlSegment("key", key);
-        AssertOk(_restClient.Execute<object>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<object>(restRequest));
     }
 
-    public string RegenerateSecretKey(string key)
+    public async Task<string> RegenerateSecretKeyAsync(string key)
     {
         var restRequest = new RestRequest("/workspaces/{key}/actions/regenerate-secret-key", Method.Post)
             .AddUrlSegment("key", key);
-        var response = AssertOk(_restClient.Execute<Dictionary<string, string>>(restRequest));
+        var response = AssertOk(await _restClient.ExecuteAsync<Dictionary<string, string>>(restRequest));
         return response["secretKey"];
     }  
         
-    public void Activate(string key)
+    public async Task ActivateAsync(string key)
     {
         var restRequest = new RestRequest("/workspaces/{key}/actions/activate", Method.Post)
             .AddUrlSegment("key", key);
-        AssertOk(_restClient.Execute<Dictionary<string, string>>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<Dictionary<string, string>>(restRequest));
     }   
         
-    public void Deactivate(string key)
+    public async Task DeactivateAsync(string key)
     {
         var restRequest = new RestRequest("/workspaces/{key}/actions/deactivate", Method.Post)
             .AddUrlSegment("key", key);
-        AssertOk(_restClient.Execute<Dictionary<string, string>>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<Dictionary<string, string>>(restRequest));
     }  
         
-    public void SetDefault(string key)
+    public async Task SetDefaultAsync(string key)
     {
         var restRequest = new RestRequest("/workspaces/actions/set-default/{key}", Method.Post)
             .AddUrlSegment("key", key);
-        AssertOk(_restClient.Execute<Dictionary<string, string>>(restRequest));
+        AssertOk(await _restClient.ExecuteAsync<Dictionary<string, string>>(restRequest));
     }
 
-    public IEnumerable<Workspace> ListAll(string filter = null)
+    public IAsyncEnumerable<Workspace> ListAllAsync(string filter = null)
     {
         return ParametrizedList().All(filter);
     }
 
-    public Page<Workspace> ListFirstPage(int? pageSize = null, string filter = null)
+    public async Task<Page<Workspace>> ListFirstPageAsync(int? pageSize = null, string filter = null)
     {
-        return ParametrizedList().FirstPage(filter, pageSize);
+        return await ParametrizedList().FirstPage(filter, pageSize);
     }
 
-    public Page<Workspace> ListPageAfter(long id, int? pageSize = null, string filter = null)
+    public async Task<Page<Workspace>> ListPageAfterAsync(long id, int? pageSize = null, string filter = null)
     {
-        return ParametrizedList().PageAfter(id, filter, pageSize);
+        return await ParametrizedList().PageAfter(id, filter, pageSize);
     }
 
-    public Page<Workspace> ListPageBefore(long id, int? pageSize = null, string filter = null)
+    public async Task<Page<Workspace>> ListPageBeforeAsync(long id, int? pageSize = null, string filter = null)
     {
-        return ParametrizedList().PageBefore(id, filter, pageSize);
+        return await ParametrizedList().PageBefore(id, filter, pageSize);
     }
 
     private WorkspaceLister ParametrizedList()


### PR DESCRIPTION
- Update all method to be Async
- Updated the Function Names to reflect Async
This will force to update the code and make sure to add await in the consumer code
- Returning AsyncEnumerables for the paged requests endpoints
- Currently not supporting the sync endpoints
Should it be?

#55 