### PR TITLE
Add option to inject an HTTPClient instance

### DIFF
--- a/SeatsioDotNet.Test/SeatsioClientHttpClientTest.cs
+++ b/SeatsioDotNet.Test/SeatsioClientHttpClientTest.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Authentication.ExtendedProtection;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Polly;
+using Polly.Retry;
+using Xunit;
+
+namespace SeatsioDotNet.Test;
+
+public class SeatsioClientHttpClientTest : SeatsioClientTest
+{
+    [Fact]
+    public async Task ReuseHttpClientAcrossMultipleSeatsIoClients()
+    {
+        var retryPipeline = new ResiliencePipelineBuilder()
+            .AddRetry(new RetryStrategyOptions()
+            {
+                ShouldHandle = new PredicateBuilder().Handle<RateLimitExceededException>(),
+                BackoffType = DelayBackoffType.Exponential,
+                UseJitter = true,
+                MaxRetryAttempts = 5,
+            }).Build();
+
+        var workspace1 = await Client.Workspaces.CreateAsync("workspace1");
+        var workspace2 = await Client.Workspaces.CreateAsync("workspace2");
+
+        using var httpClient = new HttpClient();
+        var workspace1Client = CreateSeatsioClient(workspace1.SecretKey, httpClient);
+        var workspace2Client = CreateSeatsioClient(workspace2.SecretKey, httpClient);
+
+        var c1w1 = retryPipeline.ExecuteAsync(async _ => await  workspace1Client.Charts.CreateAsync("chart1-workspace1"));
+        var c1w2 = retryPipeline.ExecuteAsync(async _ => await workspace2Client.Charts.CreateAsync("chart1-workspace2"));
+        var c2w2 = retryPipeline.ExecuteAsync(async _ => await workspace2Client.Charts.CreateAsync("chart2-workspace2"));
+        var c2w1 = retryPipeline.ExecuteAsync(async _ => await workspace1Client.Charts.CreateAsync("chart2-workspace1"));
+        var c3w1 = retryPipeline.ExecuteAsync(async _ => await workspace2Client.Charts.CreateAsync("chart3-workspace2"));
+
+        await Task.WhenAll(c1w1.AsTask(), c1w2.AsTask(), c2w2.AsTask(), c2w1.AsTask(), c3w1.AsTask());
+
+        var workspace1Charts = await retryPipeline.ExecuteAsync(async _ => await workspace1Client.Charts.ListAllAsync().ToListAsync());
+        var workspace2Charts = await retryPipeline.ExecuteAsync(async _ => await workspace2Client.Charts.ListAllAsync().ToListAsync());
+
+        workspace1Charts
+            .Select(a => a.Name)
+            .Should()
+            .BeEquivalentTo("chart1-workspace1", "chart2-workspace1");
+
+        workspace2Charts
+            .Select(a => a.Name)
+            .Should()
+            .BeEquivalentTo("chart1-workspace2", "chart2-workspace2", "chart3-workspace2");
+    }
+}

--- a/SeatsioDotNet.Test/SeatsioClientTest.cs
+++ b/SeatsioDotNet.Test/SeatsioClientTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using RestSharp;
@@ -91,6 +92,9 @@ public class SeatsioClientTest
     {
         return new SeatsioClient(secretKey, workspaceKey, BaseUrl);
     }
+
+    protected SeatsioClient CreateSeatsioClient(string secretKey, HttpClient httpClient, string workspaceKey = null)
+        => new SeatsioClient(secretKey, workspaceKey, BaseUrl, httpClient);
 
     protected async Task WaitForStatusChanges(SeatsioClient client, Event evnt, int numStatusChanges)
     {

--- a/SeatsioDotNet.Test/SeatsioDotNet.Test.csproj
+++ b/SeatsioDotNet.Test/SeatsioDotNet.Test.csproj
@@ -6,6 +6,7 @@
 	<ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
 		<ProjectReference Include="..\SeatsioDotNet\SeatsioDotNet.csproj" />
+		<PackageReference Include="Polly.Core" Version="8.3.1" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <PrivateAssets>all</PrivateAssets>

--- a/SeatsioDotNet/SeatsioClient.cs
+++ b/SeatsioDotNet/SeatsioClient.cs
@@ -31,9 +31,9 @@ namespace SeatsioDotNet
             ServicePointManager.SecurityProtocol = ServicePointManager.SecurityProtocol | SecurityProtocolType.Tls12;
         }
 
-        public SeatsioClient(string secretKey, string workspaceKey, string baseUrl)
+        public SeatsioClient(string secretKey, string workspaceKey, string baseUrl, HttpClient httpClient = null)
         {
-            RestClient = CreateRestClient(secretKey, workspaceKey, baseUrl);
+            RestClient = CreateRestClient(secretKey, workspaceKey, baseUrl, httpClient);
             Charts = new Charts.Charts(RestClient);
             Events = new Events.Events(RestClient);
             Workspaces = new Workspaces.Workspaces(RestClient);
@@ -54,13 +54,13 @@ namespace SeatsioDotNet
         {
         }
 
-        private static SeatsioRestClient CreateRestClient(string secretKey, string workspaceKey, string baseUrl)
+        private static SeatsioRestClient CreateRestClient(string secretKey, string workspaceKey, string baseUrl, HttpClient httpClient)
         {
             var options = new RestClientOptions(baseUrl)
             {
                 Authenticator = new HttpBasicAuthenticator(secretKey, null)
             };
-            var client = new SeatsioRestClient(options);
+            var client = new SeatsioRestClient(options, httpClient: httpClient);
             client.AddDefaultHeader("X-Client-Lib", ".NET");
 
             if (!string.IsNullOrEmpty(workspaceKey))
@@ -75,8 +75,8 @@ namespace SeatsioDotNet
 
 public class SeatsioRestClient : RestClient
 {
-    public SeatsioRestClient(RestClientOptions restClientOptions, int maxRetries = 5) : base(
-        new HttpClient(new SeatsioMessageHandler(maxRetries)),
+    public SeatsioRestClient(RestClientOptions restClientOptions, int maxRetries = 5, HttpClient httpClient = null) : base(
+        httpClient ?? new HttpClient(new SeatsioMessageHandler(maxRetries)),
         restClientOptions,
         configureSerialization: s =>
             s.UseSerializer(() => new SystemTextJsonSerializer(SeatsioJsonSerializerOptions())))


### PR DESCRIPTION
Bring Your Own HttpClient instance if you don't want to create a new one internally every time a new instance of the `SeatsioClient` is created.

When bringing your own client, you are responsible to manage retries for calls made to the API.

Recommended Usage of HttpClient instances is by [using the HttpClientFactory](https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines) and avoiding newing up an instance each time. This can soon lead to socket exceptions etc.