### PR TITLE
Support string CategoryKey on ChartObjectInfo

### DIFF
--- a/SeatsioDotNet.Test/Reports/Charts/ChartReportsTest.cs
+++ b/SeatsioDotNet.Test/Reports/Charts/ChartReportsTest.cs
@@ -43,7 +43,7 @@ public class ChartReportsTest : SeatsioClientTest
         reportItem.Labels.Should().BeEquivalentTo(new Labels("1", "seat", "A", "row"));
         reportItem.IDs.Should().BeEquivalentTo(new IDs("1", "A", null));
         Assert.Equal("Cat1", reportItem.CategoryLabel);
-        Assert.Equal(9, reportItem.CategoryKey);
+        Assert.Equal("9", reportItem.CategoryKey);
         Assert.Equal("seat", reportItem.ObjectType);
         Assert.Null(reportItem.Section);
         Assert.Null(reportItem.Entrance);

--- a/SeatsioDotNet.Test/resources/sampleChartWithSections.json
+++ b/SeatsioDotNet.Test/resources/sampleChartWithSections.json
@@ -8,7 +8,7 @@
         "label": "cat1",
         "color": "#AEDB54",
         "accessible": false,
-        "key": 1
+        "key": "019b4f41-9cd8-4988-9d74-308563a089a2"
       },
       {
         "label": "cat2",
@@ -59,7 +59,7 @@
         "labelRotationAngle": 0,
         "uuid": "uuid2",
         "categoryLabel": "cat1",
-        "categoryKey": 1,
+        "categoryKey": "019b4f41-9cd8-4988-9d74-308563a089a2",
         "topLeft": {
           "x": 0,
           "y": 0

--- a/SeatsioDotNet/Charts/ChartObjectInfo.cs
+++ b/SeatsioDotNet/Charts/ChartObjectInfo.cs
@@ -8,7 +8,7 @@ public class ChartObjectInfo
     public Labels Labels { get; set; }
     public IDs IDs { get; set; }
     public string CategoryLabel { get; set; }
-    public int? CategoryKey { get; set; }
+    public string CategoryKey { get; set; }
     public string ObjectType { get; set; }
     public string Section { get; set; }
     public string Entrance { get; set; }


### PR DESCRIPTION
Adding a category supports string keys/guids.
Update the reports response object to support the same.