### PR TITLE
Remove update chart key for event

### DIFF
--- a/SeatsioDotNet.Test/Events/UpdateEventTest.cs
+++ b/SeatsioDotNet.Test/Events/UpdateEventTest.cs
@@ -10,21 +10,6 @@ namespace SeatsioDotNet.Test.Events;
 public class UpdateEventTest : SeatsioClientTest
 {
     [Fact]
-    public async Task UpdateChartKey()
-    {
-        var chartKey1 = CreateTestChart();
-        var chartKey2 = CreateTestChart();
-        var evnt = await Client.Events.CreateAsync(chartKey1);
-
-        await Client.Events.UpdateAsync(evnt.Key, new UpdateEventParams().WithChartKey(chartKey2));
-
-        var retrievedEvent = await Client.Events.RetrieveAsync(evnt.Key);
-        Assert.Equal(evnt.Key, retrievedEvent.Key);
-        Assert.Equal(chartKey2, retrievedEvent.ChartKey);
-        CustomAssert.CloseTo(DateTimeOffset.Now, retrievedEvent.UpdatedOn.Value);
-    }
-
-    [Fact]
     public async Task UpdateEventKey()
     {
         var chartKey = CreateTestChart();

--- a/SeatsioDotNet/Events/Events.cs
+++ b/SeatsioDotNet/Events/Events.cs
@@ -135,11 +135,6 @@ public class Events
     {
         Dictionary<string, object> requestBody = new Dictionary<string, object>();
 
-        if (p.ChartKey != null)
-        {
-            requestBody.Add("chartKey", p.ChartKey);
-        }
-
         if (p.Key != null)
         {
             requestBody.Add("eventKey", p.Key);

--- a/SeatsioDotNet/Events/UpdateEventParams.cs
+++ b/SeatsioDotNet/Events/UpdateEventParams.cs
@@ -7,7 +7,6 @@ namespace SeatsioDotNet.Events;
 public class UpdateEventParams
 {
     public string Key { get; set; }
-    public string ChartKey { get; set; }
     public string Name { get; set; }
     public DateOnly? Date { get; set; }
     public TableBookingConfig TableBookingConfig { get; set; }
@@ -18,12 +17,6 @@ public class UpdateEventParams
     public UpdateEventParams WithKey(string key)
     {
         Key = key;
-        return this;
-    }
-
-    public UpdateEventParams WithChartKey(string chartKey)
-    {
-        ChartKey = chartKey;
         return this;
     }
 


### PR DESCRIPTION
Updating the chart key of an event is no longer documented but is still supported by the client libraries. This PR removes the parameter from `UpdateEventParams`.