### PR TITLE
Distinct exception type thrown when best available objects not found

### DIFF
--- a/SeatsioDotNet.Test/Events/Channels/AddChannelTest.cs
+++ b/SeatsioDotNet.Test/Events/Channels/AddChannelTest.cs
@@ -74,7 +74,7 @@ public class AddChannelTest : SeatsioClientTest
         await Client.Events.Channels.AddAsync(event1.Key, "channelKey1", "channel 1", "#FFFF98", null, new[] {"A-1", "A-2"});
 
         var retrievedEvent = await Client.Events.RetrieveAsync(event1.Key);
-        Assert.Equal(1, retrievedEvent.Channels.Count);
+        Assert.Single(retrievedEvent.Channels);
 
         var channel1 = retrievedEvent.Channels[0];
         Assert.Equal("channelKey1", channel1.Key);
@@ -92,7 +92,7 @@ public class AddChannelTest : SeatsioClientTest
         await Client.Events.Channels.AddAsync(event1.Key, "channelKey1", "channel 1", "#FFFF98", 1, null);
 
         var retrievedEvent = await Client.Events.RetrieveAsync(event1.Key);
-        Assert.Equal(1, retrievedEvent.Channels.Count);
+        Assert.Single(retrievedEvent.Channels);
 
         var channel1 = retrievedEvent.Channels[0];
         Assert.Equal("channelKey1", channel1.Key);

--- a/SeatsioDotNet.Test/Events/CreateEventsTest.cs
+++ b/SeatsioDotNet.Test/Events/CreateEventsTest.cs
@@ -35,7 +35,7 @@ public class CreateEventsTest : SeatsioClientTest
 
         var events = await Client.Events.CreateAsync(chartKey, eventCreationParams);
 
-        Assert.Equal(1, events.Length);
+        Assert.Single(events);
         var e = events[0];
         Assert.NotNull(e.Id);
         Assert.NotNull(e.Key);

--- a/SeatsioDotNet/BestAvailableObjectsNotFoundException.cs
+++ b/SeatsioDotNet/BestAvailableObjectsNotFoundException.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace SeatsioDotNet;
+
+public class BestAvailableObjectsNotFoundException : SeatsioException
+{
+    public BestAvailableObjectsNotFoundException(List<SeatsioApiError> errors, string requestId) :
+        base(errors, requestId)
+    {
+    }
+}

--- a/SeatsioDotNet/SeatsioException.cs
+++ b/SeatsioDotNet/SeatsioException.cs
@@ -43,11 +43,20 @@ public class SeatsioException : Exception
             {
                 return new RateLimitExceededException(parsedException.Errors, parsedException.RequestId);
             }
+            else if (IsBestAvailableObjectsNotFound(parsedException))
+            {
+                return new BestAvailableObjectsNotFoundException(parsedException.Errors, parsedException.RequestId);
+            }
 
             return new SeatsioException(parsedException.Errors, parsedException.RequestId);
         }
 
         return new SeatsioException(response);
+    }
+
+    private static bool IsBestAvailableObjectsNotFound(SeatsioExceptionTo parsedException)
+    {
+        return parsedException.Errors.Any(e => e.Code == "BEST_AVAILABLE_OBJECTS_NOT_FOUND");
     }
 
     public struct SeatsioExceptionTo


### PR DESCRIPTION
Instead of throwing a generic SeatsioException (which is thrown in many cases, eg no focal point, event not found, etc), we now throw a BestAvailableObjectsNotFoundException (subclass of SeatsioException) to make it easier to handle this common specific case.