### PR TITLE
Move event to a new chart copy

### DIFF
--- a/SeatsioDotNet.Test/Events/MoveEventToNewChartCopyTest.cs
+++ b/SeatsioDotNet.Test/Events/MoveEventToNewChartCopyTest.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+using SeatsioDotNet.Events;
+using Xunit;
+
+namespace SeatsioDotNet.Test.Events;
+
+public class MoveEventToNewChartCopyTest : SeatsioClientTest
+{
+    [Fact]
+    public async Task TestEventIsMovedToNewChartCopy()
+    {
+        var chartKey = CreateTestChart();
+        var evnt = await Client.Events.CreateAsync(chartKey);
+        Event movedEvent = await Client.Events.MoveEventToNewChartCopy(evnt.Key);
+        
+        Assert.NotEqual(evnt.ChartKey, movedEvent.ChartKey);
+        Assert.Equal(evnt.Key, movedEvent.Key);
+    }
+}

--- a/SeatsioDotNet/Events/Events.cs
+++ b/SeatsioDotNet/Events/Events.cs
@@ -561,6 +561,13 @@ public class Events
         AssertOk(await _restClient.ExecuteAsync<object>(restRequest, cancellationToken));
     }
 
+    public async Task<Event> MoveEventToNewChartCopy(string eventKey, CancellationToken cancellationToken = default)
+    {
+        var restRequest = new RestRequest("/events/{key}/actions/move-to-new-chart-copy", Method.Post)
+            .AddUrlSegment("key", eventKey);
+        return AssertOk(await _restClient.ExecuteAsync<Event>(restRequest, cancellationToken));
+    }
+
     private Dictionary<string, object> ForSaleRequest(IEnumerable<string> objects,
         Dictionary<string, int> areaPlaces, IEnumerable<string> categories)
     {


### PR DESCRIPTION
Creates a new copy of the chart the event belongs to, and moves the event to that chart.